### PR TITLE
feat: pressure-advance tool, thumbnails, and printer metadata

### DIFF
--- a/src/filament_calibrator/cli.py
+++ b/src/filament_calibrator/cli.py
@@ -28,7 +28,7 @@ from filament_calibrator.slicer import (
     slice_tower,
 )
 from filament_calibrator.tempinsert import compute_temp_tiers, insert_temperatures
-from filament_calibrator.thumbnail import inject_thumbnails
+from filament_calibrator.thumbnail import inject_thumbnails, patch_slicer_metadata
 
 # Sentinel used to detect whether the user explicitly supplied a value.
 _UNSET = object()
@@ -461,6 +461,10 @@ def run(args: argparse.Namespace) -> None:
     print(f"Inserting temperatures → {final_gcode_path}")
     gf = gl.load(raw_gcode_path)
     inject_thumbnails(gf, stl_path, DEFAULT_THUMBNAILS, verbose=args.verbose)
+    if printer_name is not None:
+        patch_slicer_metadata(
+            gf, printer_name, nozzle_size, verbose=args.verbose
+        )
     tiers = compute_temp_tiers(
         start_temp=config.start_temp,
         temp_step=config.temp_step,

--- a/src/filament_calibrator/flow_cli.py
+++ b/src/filament_calibrator/flow_cli.py
@@ -34,7 +34,7 @@ from filament_calibrator.slicer import (
     DEFAULT_THUMBNAILS,
     slice_flow_specimen,
 )
-from filament_calibrator.thumbnail import inject_thumbnails
+from filament_calibrator.thumbnail import inject_thumbnails, patch_slicer_metadata
 
 
 # Maximum number of flow levels to prevent excessively tall prints.
@@ -424,6 +424,10 @@ def run(args: argparse.Namespace) -> None:
     print(f"Inserting flow rates → {final_gcode_path}")
     gf = gl.load(raw_gcode_path)
     inject_thumbnails(gf, stl_path, DEFAULT_THUMBNAILS, verbose=args.verbose)
+    if printer_name is not None:
+        patch_slicer_metadata(
+            gf, printer_name, nozzle_size, verbose=args.verbose
+        )
     levels = compute_flow_levels(
         start_flow=args.start_speed,
         flow_step=args.step,

--- a/src/filament_calibrator/pa_cli.py
+++ b/src/filament_calibrator/pa_cli.py
@@ -40,7 +40,7 @@ from filament_calibrator.slicer import (
     DEFAULT_THUMBNAILS,
     slice_pa_specimen,
 )
-from filament_calibrator.thumbnail import inject_thumbnails
+from filament_calibrator.thumbnail import inject_thumbnails, patch_slicer_metadata
 
 
 # Maximum number of PA levels to prevent excessively tall prints.
@@ -480,6 +480,10 @@ def run(args: argparse.Namespace) -> None:
     print(f"Inserting PA commands → {final_gcode_path}")
     gf = gl.load(raw_gcode_path)
     inject_thumbnails(gf, stl_path, DEFAULT_THUMBNAILS, verbose=args.verbose)
+    if printer_name is not None:
+        patch_slicer_metadata(
+            gf, printer_name, nozzle_size, verbose=args.verbose
+        )
     levels = compute_pa_levels(
         start_pa=args.start_pa,
         pa_step=args.pa_step,

--- a/src/filament_calibrator/thumbnail.py
+++ b/src/filament_calibrator/thumbnail.py
@@ -20,8 +20,13 @@ import gcode_lib as gl
 # bgcode block constants (matching gcode_lib internals)
 # ---------------------------------------------------------------------------
 
+_BLK_FILE_METADATA: int = 0
+_BLK_SLICER_METADATA: int = 2
+_BLK_PRINTER_METADATA: int = 3
+_BLK_PRINT_METADATA: int = 4
 _BLK_THUMBNAIL: int = 5
 _COMP_NONE: int = 0
+_COMP_DEFLATE: int = 1
 _IMG_PNG: int = 0
 
 # ---------------------------------------------------------------------------
@@ -134,9 +139,12 @@ def build_thumbnail_block(png_data: bytes, width: int, height: int) -> bytes:
 
     The returned bytes are suitable for inserting into
     ``GCodeFile._bgcode_nongcode_blocks``.
+
+    The 6-byte params field follows the libbgcode spec order:
+    ``format (u16) | width (u16) | height (u16)``.
     """
     hdr = struct.pack("<HHI", _BLK_THUMBNAIL, _COMP_NONE, len(png_data))
-    params = struct.pack("<HHH", width, height, _IMG_PNG)
+    params = struct.pack("<HHH", _IMG_PNG, width, height)
     cksum = zlib.crc32(hdr) & 0xFFFFFFFF
     cksum = zlib.crc32(params, cksum) & 0xFFFFFFFF
     cksum = zlib.crc32(png_data, cksum) & 0xFFFFFFFF
@@ -179,16 +187,23 @@ def inject_thumbnails(
                 )
             png_data = render_stl_to_png(stl_path, spec.width, spec.height)
             block = build_thumbnail_block(png_data, spec.width, spec.height)
-            params = struct.pack("<HHH", spec.width, spec.height, _IMG_PNG)
+            # gcode_lib's Thumbnail.params uses width,height,format order
+            # for .width/.height properties (differs from the bgcode spec's
+            # format,width,height in the raw block).
+            gl_params = struct.pack("<HHH", spec.width, spec.height, _IMG_PNG)
             new_blocks.append(block)
             new_thumbs.append(
-                gl.Thumbnail(params=params, data=png_data, _raw_block=block)
+                gl.Thumbnail(params=gl_params, data=png_data, _raw_block=block)
             )
 
-        # Prepend thumbnail blocks (convention: thumbnails before metadata).
+        # Insert thumbnail blocks after PRINTER_METADATA (type 3) and
+        # before PRINT_METADATA (type 4), matching PrusaSlicer's native
+        # block order.
         if gf._bgcode_nongcode_blocks is None:
             gf._bgcode_nongcode_blocks = []  # pragma: no cover
-        gf._bgcode_nongcode_blocks[:0] = new_blocks
+        insert_pos = _find_thumbnail_insert_pos(gf._bgcode_nongcode_blocks)
+        for i, blk in enumerate(new_blocks):
+            gf._bgcode_nongcode_blocks.insert(insert_pos + i, blk)
         gf.thumbnails.extend(new_thumbs)
 
         if verbose:
@@ -196,6 +211,158 @@ def inject_thumbnails(
 
     except Exception as exc:
         warnings.warn(f"Thumbnail injection failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Slicer metadata patching
+# ---------------------------------------------------------------------------
+
+# PrusaSlicer G-code Viewer uses ``printer_settings_id`` from the slicer
+# metadata block to look up the bed model from its bundled vendor profiles.
+# PrusaSlicer CLI leaves this field empty, so we patch it post-slicing.
+# Map: (printer_model, nozzle_diameter_str) → printer_settings_id.
+_PRINTER_SETTINGS_IDS: dict[tuple[str, str], str] = {
+    ("COREONE", "0.25"): "Prusa CORE One 0.25 nozzle",
+    ("COREONE", "0.3"):  "Prusa CORE One 0.3 nozzle",
+    ("COREONE", "0.4"):  "Prusa CORE One HF0.4 nozzle",
+    ("COREONE", "0.5"):  "Prusa CORE One HF0.5 nozzle",
+    ("COREONE", "0.6"):  "Prusa CORE One HF0.6 nozzle",
+    ("COREONE", "0.8"):  "Prusa CORE One HF0.8 nozzle",
+}
+
+
+def patch_slicer_metadata(
+    gf: gl.GCodeFile,
+    printer_model: str,
+    nozzle_diameter: float,
+    *,
+    verbose: bool = False,
+) -> None:
+    """Patch the SLICER_METADATA block to set ``printer_settings_id``.
+
+    PrusaSlicer CLI leaves ``printer_settings_id`` empty in the slicer
+    metadata block.  The G-code Viewer needs this field to look up the
+    printer bed model from its bundled vendor profiles.  This function
+    patches the existing SLICER_METADATA block in-place.
+
+    Does nothing for ASCII G-code or if no matching profile is found.
+    Failures are non-fatal.
+    """
+    if gf.source_format != "bgcode":
+        return
+
+    nozzle_str = f"{nozzle_diameter:g}"
+    settings_id = _PRINTER_SETTINGS_IDS.get((printer_model, nozzle_str))
+    if settings_id is None:
+        if verbose:
+            print(
+                f"[DEBUG] No printer_settings_id mapping for "
+                f"({printer_model}, {nozzle_str})"
+            )
+        return
+
+    blocks = gf._bgcode_nongcode_blocks
+    if not blocks:
+        return
+
+    try:
+        idx = _find_slicer_meta_index(blocks)
+        if idx is None:
+            return
+
+        old_block = blocks[idx]
+        new_block = _rebuild_slicer_meta_block(
+            old_block,
+            {"printer_settings_id": settings_id},
+        )
+        blocks[idx] = new_block
+
+        if verbose:
+            print(f"[DEBUG] Patched printer_settings_id={settings_id}")
+
+    except Exception as exc:
+        warnings.warn(f"Slicer metadata patch failed: {exc}")
+
+
+def _find_slicer_meta_index(blocks: list[bytes]) -> int | None:
+    """Return the index of the SLICER_METADATA block, or ``None``."""
+    for i, blk in enumerate(blocks):
+        btype = struct.unpack_from("<H", blk, 0)[0]
+        if btype == _BLK_SLICER_METADATA:
+            return i
+    return None
+
+
+def _rebuild_slicer_meta_block(
+    raw_block: bytes,
+    updates: dict[str, str],
+) -> bytes:
+    """Rebuild a SLICER_METADATA block with updated key=value pairs.
+
+    Handles both uncompressed and deflate-compressed blocks.
+    """
+    btype, comp, usize = struct.unpack_from("<HHI", raw_block, 0)
+    assert btype == _BLK_SLICER_METADATA
+
+    if comp == _COMP_NONE:
+        # header(8) + params(2) + payload(usize) + crc(4)
+        params = raw_block[8:10]
+        payload = raw_block[10 : 10 + usize]
+    elif comp == _COMP_DEFLATE:
+        # header(8) + compressed_size(4) + params(2) + payload(cs) + crc(4)
+        cs = struct.unpack_from("<I", raw_block, 8)[0]
+        params = raw_block[12:14]
+        compressed = raw_block[14 : 14 + cs]
+        payload = zlib.decompress(compressed)
+    else:
+        # Heatshrink or unknown — can't patch, return as-is.
+        return raw_block
+
+    # Apply updates to the INI-style text (line-anchored to avoid
+    # partial matches like physical_printer_settings_id).
+    import re
+
+    text = payload.decode("utf-8")
+    for key, value in updates.items():
+        pattern = rf"^{re.escape(key)}=.*$"
+        if re.search(pattern, text, flags=re.MULTILINE):
+            text = re.sub(pattern, f"{key}={value}", text, flags=re.MULTILINE)
+        else:
+            text = text.rstrip("\n") + f"\n{key}={value}\n"
+
+    new_payload = text.encode("utf-8")
+
+    # Rebuild the block.
+    new_hdr = struct.pack("<HHI", btype, comp, len(new_payload))
+    if comp == _COMP_DEFLATE:
+        new_compressed = zlib.compress(new_payload)
+        cs_bytes = struct.pack("<I", len(new_compressed))
+        block_body = new_hdr + cs_bytes + params + new_compressed
+    else:
+        block_body = new_hdr + params + new_payload
+
+    crc = struct.pack("<I", zlib.crc32(block_body) & 0xFFFFFFFF)
+    return block_body + crc
+
+
+# ---------------------------------------------------------------------------
+# Private — block ordering
+# ---------------------------------------------------------------------------
+
+
+def _find_thumbnail_insert_pos(blocks: list[bytes]) -> int:
+    """Return the index at which thumbnail blocks should be inserted.
+
+    PrusaSlicer orders blocks as FILE_METADATA → PRINTER_METADATA →
+    THUMBNAIL(s) → PRINT_METADATA → SLICER_METADATA.  We insert after
+    the last FILE_METADATA or PRINTER_METADATA block (types 0 and 3).
+    """
+    pos = 0
+    for i, blk in enumerate(blocks):
+        btype = struct.unpack_from("<H", blk, 0)[0]
+        if btype in (_BLK_FILE_METADATA, _BLK_PRINTER_METADATA):
+            pos = i + 1
+    return pos
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -492,6 +492,7 @@ class TestRun:
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -506,7 +507,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -530,6 +531,7 @@ class TestRun:
         mock_insert.assert_called_once()
         mock_save.assert_called_once()
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -544,7 +546,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -556,6 +558,7 @@ class TestRun:
             run(args)
         assert exc_info.value.code == 1
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -571,7 +574,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save, mock_upload,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -595,6 +598,7 @@ class TestRun:
         assert call_kwargs[1]["api_key"] == "key123"
         assert call_kwargs[1]["print_after_upload"] is True
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -609,7 +613,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -627,6 +631,7 @@ class TestRun:
             run(args)
         assert exc_info.value.code == 1
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -641,7 +646,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         # PLA preset: high=230, low=190, jump=5 → 9 tiers
         stl = tmp_path / "temp_tower_PLA_230_5x9.stl"
@@ -661,6 +666,7 @@ class TestRun:
         assert stl.exists()
         assert raw_gcode.exists()
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -675,7 +681,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         stl = tmp_path / "temp_tower_PLA_230_5x9.stl"
         raw_gcode = tmp_path / "temp_tower_PLA_230_5x9_raw.bgcode"
@@ -694,6 +700,7 @@ class TestRun:
         assert not stl.exists()
         assert not raw_gcode.exists()
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -708,7 +715,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -723,6 +730,7 @@ class TestRun:
         assert slice_kwargs["bed_temp"] == 85
         assert slice_kwargs["fan_speed"] == 50
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -737,7 +745,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         # Write a TOML config that sets filament-type to PETG
         cfg = tmp_path / "test.toml"
@@ -757,6 +765,7 @@ class TestRun:
         tower_config = gen_call[0][0]
         assert tower_config.filament_type == "PETG"
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -771,7 +780,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         cfg = tmp_path / "test.toml"
         cfg.write_text('filament-type = "PETG"\n')
@@ -792,6 +801,7 @@ class TestRun:
         tower_config = gen_call[0][0]
         assert tower_config.filament_type == "ABS"
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -806,7 +816,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -820,6 +830,7 @@ class TestRun:
         slice_kwargs = mock_slice.call_args[1]
         assert slice_kwargs["bed_center"] == "90,90"
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -834,7 +845,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -858,6 +869,7 @@ class TestRun:
         assert "PrusaSlicer command:" in captured.out
         assert "Temperature tiers:" in captured.out
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -872,7 +884,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -889,6 +901,7 @@ class TestRun:
         captured = capsys.readouterr()
         assert "PrusaSlicer stdout: Slicing complete in 3.2s" in captured.out
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -903,7 +916,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -917,6 +930,7 @@ class TestRun:
         captured = capsys.readouterr()
         assert "[DEBUG]" not in captured.out
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -931,7 +945,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         cfg = tmp_path / "test.toml"
         cfg.write_text('filament-type = "PLA"\n')
@@ -952,6 +966,7 @@ class TestRun:
         assert str(cfg) in captured.out
         assert "Config values:" in captured.out
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -967,7 +982,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save, mock_upload,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -991,6 +1006,7 @@ class TestRun:
         assert "Upload target: http://192.168.1.100" in captured.out
         assert "Print after upload: True" in captured.out
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -1005,7 +1021,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -1022,6 +1038,7 @@ class TestRun:
         assert "not in presets" in captured.out
         assert "fallback defaults" in captured.out
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -1036,7 +1053,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """--ascii-gcode uses .gcode extension for filenames."""
         stl = tmp_path / "temp_tower_PLA_230_5x9.stl"
@@ -1061,6 +1078,7 @@ class TestRun:
         assert save_path.endswith(".gcode")
         assert not save_path.endswith(".bgcode")
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -1075,7 +1093,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """binary_gcode=True is passed to slice_tower by default."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -1090,6 +1108,7 @@ class TestRun:
         slice_kwargs = mock_slice.call_args[1]
         assert slice_kwargs["binary_gcode"] is True
 
+    @patch("filament_calibrator.cli.patch_slicer_metadata")
     @patch("filament_calibrator.cli.inject_thumbnails")
     @patch("filament_calibrator.cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.cli.compute_bed_center", return_value="125,110")
@@ -1104,7 +1123,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_tiers,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """--ascii-gcode sets binary_gcode=False in slice_tower call."""
         mock_gen.return_value = str(tmp_path / "tower.stl")

--- a/tests/test_flow_cli.py
+++ b/tests/test_flow_cli.py
@@ -266,6 +266,7 @@ class TestRun:
         return argparse.Namespace(**defaults)
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -280,7 +281,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -299,6 +300,7 @@ class TestRun:
         mock_save.assert_called_once()
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -313,7 +315,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(
@@ -326,6 +328,7 @@ class TestRun:
         assert exc_info.value.code == 1
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -341,7 +344,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save, mock_upload,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -366,6 +369,7 @@ class TestRun:
         assert call_kwargs["print_after_upload"] is True
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -380,7 +384,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         args = self._make_args(
             tmp_path,
@@ -393,6 +397,7 @@ class TestRun:
         assert exc_info.value.code == 1
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -407,7 +412,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         stl = tmp_path / "flow_specimen_PLA_5.0_5.0x2.stl"
         raw_gcode = tmp_path / "flow_specimen_PLA_5.0_5.0x2_raw.bgcode"
@@ -427,6 +432,7 @@ class TestRun:
         assert raw_gcode.exists()
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -441,7 +447,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         stl = tmp_path / "flow_specimen_PLA_5.0_5.0x2.stl"
         raw_gcode = tmp_path / "flow_specimen_PLA_5.0_5.0x2_raw.bgcode"
@@ -461,6 +467,7 @@ class TestRun:
         assert not raw_gcode.exists()
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -475,7 +482,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(
@@ -499,6 +506,7 @@ class TestRun:
         assert "Flow levels:" in captured.out
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -513,7 +521,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -528,6 +536,7 @@ class TestRun:
         assert "[DEBUG]" not in captured.out
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -542,7 +551,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(
@@ -560,6 +569,7 @@ class TestRun:
         assert "PrusaSlicer stdout: Slicing complete in 2.1s" in captured.out
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -574,7 +584,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(
@@ -592,6 +602,7 @@ class TestRun:
         assert "fallback defaults" in captured.out
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -606,7 +617,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         cfg = tmp_path / "test.toml"
         cfg.write_text('filament-type = "PLA"\n')
@@ -627,6 +638,7 @@ class TestRun:
         assert str(cfg) in captured.out
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -642,7 +654,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save, mock_upload,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path, capsys
+        mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(
@@ -667,6 +679,7 @@ class TestRun:
         assert "Print after upload: True" in captured.out
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -681,7 +694,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "specimen.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -703,6 +716,7 @@ class TestRun:
         assert slice_kwargs["bed_center"] == "90,90"
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -717,7 +731,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """Filament preset nozzle/bed/fan are forwarded to slice_flow_specimen."""
         mock_gen.return_value = str(tmp_path / "specimen.stl")
@@ -736,6 +750,7 @@ class TestRun:
         assert slice_kwargs["fan_speed"] == int(pla["fan"])
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -750,7 +765,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """Explicit --nozzle-temp/--bed-temp/--fan-speed override preset in slicer call."""
         mock_gen.return_value = str(tmp_path / "specimen.stl")
@@ -774,6 +789,7 @@ class TestRun:
         assert slice_kwargs["fan_speed"] == 50
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -788,7 +804,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         cfg = tmp_path / "test.toml"
         cfg.write_text('filament-type = "PETG"\n')
@@ -807,6 +823,7 @@ class TestRun:
         assert specimen_config.filament_type == "PETG"
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -821,7 +838,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """binary_gcode=True is passed to slice_flow_specimen by default."""
         mock_gen.return_value = str(tmp_path / "specimen.stl")
@@ -837,6 +854,7 @@ class TestRun:
         assert slice_kwargs["binary_gcode"] is True
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -851,7 +869,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """--ascii-gcode sets binary_gcode=False in slice_flow_specimen call."""
         mock_gen.return_value = str(tmp_path / "specimen.stl")
@@ -867,6 +885,7 @@ class TestRun:
         assert slice_kwargs["binary_gcode"] is False
 
 
+    @patch("filament_calibrator.flow_cli.patch_slicer_metadata")
     @patch("filament_calibrator.flow_cli.inject_thumbnails")
     @patch("filament_calibrator.flow_cli.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
     @patch("filament_calibrator.flow_cli.compute_bed_center", return_value="125,110")
@@ -881,7 +900,7 @@ class TestRun:
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
         mock_resolve, mock_center, mock_shape,
-        mock_inject, tmp_path
+        mock_inject, mock_patch_meta, tmp_path
     ):
         """--ascii-gcode uses .gcode extension for filenames."""
         stl = tmp_path / "flow_specimen_PLA_5.0_5.0x2.stl"

--- a/tests/test_pa_cli.py
+++ b/tests/test_pa_cli.py
@@ -258,6 +258,8 @@ class TestRun:
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -266,7 +268,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_full_pipeline_no_upload(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -284,6 +286,8 @@ class TestRun:
         mock_insert.assert_called_once()
         mock_save.assert_called_once()
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -292,7 +296,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_slicer_failure_exits(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -304,6 +308,8 @@ class TestRun:
             run(args)
         assert exc_info.value.code == 1
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.prusalink_upload")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
@@ -313,7 +319,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_upload(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, mock_upload, tmp_path
+        mock_insert, mock_load, mock_save, mock_upload, mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -337,6 +343,8 @@ class TestRun:
         assert call_kwargs["api_key"] == "key123"
         assert call_kwargs["print_after_upload"] is True
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -345,7 +353,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_upload_missing_url_exits(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         args = self._make_args(
             tmp_path,
@@ -357,6 +365,8 @@ class TestRun:
             run(args)
         assert exc_info.value.code == 1
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -365,7 +375,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_keep_files(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         stl = tmp_path / "pa_tower_PLA_0.0_0.1x2.stl"
         raw_gcode = tmp_path / "pa_tower_PLA_0.0_0.1x2_raw.bgcode"
@@ -384,6 +394,8 @@ class TestRun:
         assert stl.exists()
         assert raw_gcode.exists()
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -392,7 +404,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_no_keep_files_cleans_up(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         stl = tmp_path / "pa_tower_PLA_0.0_0.1x2.stl"
         raw_gcode = tmp_path / "pa_tower_PLA_0.0_0.1x2_raw.bgcode"
@@ -411,6 +423,8 @@ class TestRun:
         assert not stl.exists()
         assert not raw_gcode.exists()
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -419,7 +433,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_verbose_output(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -442,6 +456,8 @@ class TestRun:
         assert "PrusaSlicer command:" in captured.out
         assert "PA levels:" in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -450,7 +466,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_no_verbose_no_debug(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -464,6 +480,8 @@ class TestRun:
         captured = capsys.readouterr()
         assert "[DEBUG]" not in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -472,7 +490,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_verbose_shows_slicer_stdout(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -489,6 +507,8 @@ class TestRun:
         captured = capsys.readouterr()
         assert "PrusaSlicer stdout: Slicing complete in 2.1s" in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -497,7 +517,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_verbose_unknown_filament(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -514,6 +534,8 @@ class TestRun:
         assert "not in presets" in captured.out
         assert "fallback defaults" in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -522,7 +544,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_verbose_shows_config_file(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         cfg = tmp_path / "test.toml"
         cfg.write_text('filament-type = "PLA"\n')
@@ -542,6 +564,8 @@ class TestRun:
         assert "Config file:" in captured.out
         assert str(cfg) in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.prusalink_upload")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
@@ -551,7 +575,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_verbose_upload(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, mock_upload, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_upload, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(
@@ -575,6 +599,8 @@ class TestRun:
         assert "Upload target: http://192.168.1.100" in captured.out
         assert "Print after upload: True" in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -583,7 +609,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_slicer_receives_correct_args(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         mock_gen.return_value = str(tmp_path / "tower.stl")
         mock_slice.return_value = MagicMock(ok=True)
@@ -604,6 +630,8 @@ class TestRun:
         assert slice_kwargs["extrusion_width"] == 0.6
         assert slice_kwargs["bed_center"] == "90,90"
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -612,7 +640,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_preset_temps_passed_to_slicer(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         """Filament preset nozzle/bed/fan are forwarded to slice_pa_specimen."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -630,6 +658,8 @@ class TestRun:
         assert slice_kwargs["bed_temp"] == int(pla["bed"])
         assert slice_kwargs["fan_speed"] == int(pla["fan"])
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -638,7 +668,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_explicit_temps_override_preset(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         """Explicit --nozzle-temp/--bed-temp/--fan-speed override preset."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -661,6 +691,8 @@ class TestRun:
         assert slice_kwargs["bed_temp"] == 90
         assert slice_kwargs["fan_speed"] == 50
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -669,7 +701,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_config_file_applies_defaults(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         cfg = tmp_path / "test.toml"
         cfg.write_text('filament-type = "PETG"\n')
@@ -687,6 +719,8 @@ class TestRun:
         tower_config = gen_call[0][0]
         assert tower_config.filament_type == "PETG"
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -695,7 +729,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_firmware_passed_to_insert(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         """--firmware is forwarded to insert_pa_commands."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -712,6 +746,8 @@ class TestRun:
 
     # --- --printer tests ---
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -723,7 +759,7 @@ class TestRun:
     def test_printer_resolves_and_sets_bed_center(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """--printer resolves printer name and auto-sets bed center."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -741,6 +777,8 @@ class TestRun:
         slice_kwargs = mock_slice.call_args[1]
         assert slice_kwargs["bed_center"] == "125,110"
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -752,7 +790,7 @@ class TestRun:
     def test_printer_explicit_bed_center_not_overridden(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """Explicit --bed-center is NOT overridden by --printer."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -771,6 +809,8 @@ class TestRun:
         slice_kwargs = mock_slice.call_args[1]
         assert slice_kwargs["bed_center"] == "100,100"
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -782,7 +822,7 @@ class TestRun:
     def test_printer_renders_start_end_gcode(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """--printer renders start/end G-code and passes to slicer."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -802,6 +842,8 @@ class TestRun:
         assert slice_kwargs["start_gcode"] == "G28\nG29\n"
         assert slice_kwargs["end_gcode"] == "M104 S0\nG28 X\n"
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -813,7 +855,7 @@ class TestRun:
     def test_printer_with_config_ini_skips_gcode_render(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """--printer with --config-ini does NOT render start/end G-code."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -833,6 +875,8 @@ class TestRun:
         assert slice_kwargs["start_gcode"] is None
         assert slice_kwargs["end_gcode"] is None
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -844,7 +888,7 @@ class TestRun:
     def test_printer_cool_fan_disabled_for_enclosure_filament(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """cool_fan=False for filaments requiring enclosure (e.g. ABS)."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -863,6 +907,8 @@ class TestRun:
         render_kwargs = mock_render_start.call_args[1]
         assert render_kwargs["cool_fan"] is False
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -874,7 +920,7 @@ class TestRun:
     def test_printer_cool_fan_enabled_for_pla(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """cool_fan=True for PLA (no enclosure required)."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -893,6 +939,8 @@ class TestRun:
         render_kwargs = mock_render_start.call_args[1]
         assert render_kwargs["cool_fan"] is True
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -904,7 +952,7 @@ class TestRun:
     def test_printer_cool_fan_true_for_unknown_filament(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path
     ):
         """cool_fan defaults to True for unknown filament types."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -923,6 +971,8 @@ class TestRun:
         render_kwargs = mock_render_start.call_args[1]
         assert render_kwargs["cool_fan"] is True
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.render_end_gcode")
     @patch("filament_calibrator.pa_cli.render_start_gcode")
     @patch("filament_calibrator.pa_cli.gl.save")
@@ -934,7 +984,7 @@ class TestRun:
     def test_verbose_printer_debug(
         self, mock_gen, mock_slice, mock_levels,
         mock_insert, mock_load, mock_save,
-        mock_render_start, mock_render_end, tmp_path, capsys
+        mock_render_start, mock_render_end, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         """Verbose mode shows printer debug info and gcode render message."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -957,6 +1007,8 @@ class TestRun:
         assert "bed center: 125,110" in captured.out
         assert "Rendered COREONE start/end G-code" in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -965,7 +1017,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_pa_lookup_table_printed(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path, capsys
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path, capsys
     ):
         """PA lookup table is always printed."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -984,6 +1036,8 @@ class TestRun:
         assert "PA value by height:" in captured.out
         assert "sharpest corners" in captured.out
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -992,7 +1046,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_binary_gcode_passed_to_slicer(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         """binary_gcode=True is passed to slice_pa_specimen by default."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -1007,6 +1061,8 @@ class TestRun:
         slice_kwargs = mock_slice.call_args[1]
         assert slice_kwargs["binary_gcode"] is True
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -1015,7 +1071,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_ascii_gcode_passes_false_to_slicer(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         """--ascii-gcode sets binary_gcode=False in slice_pa_specimen call."""
         mock_gen.return_value = str(tmp_path / "tower.stl")
@@ -1030,6 +1086,8 @@ class TestRun:
         slice_kwargs = mock_slice.call_args[1]
         assert slice_kwargs["binary_gcode"] is False
 
+    @patch("filament_calibrator.pa_cli.patch_slicer_metadata")
+    @patch("filament_calibrator.pa_cli.inject_thumbnails")
     @patch("filament_calibrator.pa_cli.gl.save")
     @patch("filament_calibrator.pa_cli.gl.load")
     @patch("filament_calibrator.pa_cli.insert_pa_commands")
@@ -1038,7 +1096,7 @@ class TestRun:
     @patch("filament_calibrator.pa_cli.generate_pa_tower_stl")
     def test_ascii_gcode_uses_gcode_extension(
         self, mock_gen, mock_slice, mock_levels,
-        mock_insert, mock_load, mock_save, tmp_path
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta, tmp_path
     ):
         """--ascii-gcode uses .gcode extension for filenames."""
         stl = tmp_path / "pa_tower_PLA_0.0_0.1x2.stl"

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -15,14 +15,23 @@ import gcode_lib as gl
 
 from filament_calibrator.thumbnail import (
     ThumbnailSpec,
+    _BLK_FILE_METADATA,
+    _BLK_PRINTER_METADATA,
+    _BLK_PRINT_METADATA,
+    _BLK_SLICER_METADATA,
     _BLK_THUMBNAIL,
+    _COMP_DEFLATE,
     _COMP_NONE,
     _IMG_PNG,
     _SUPERSAMPLE_FACTOR,
     _SUPERSAMPLE_THRESHOLD,
+    _find_slicer_meta_index,
+    _find_thumbnail_insert_pos,
+    _rebuild_slicer_meta_block,
     build_thumbnail_block,
     inject_thumbnails,
     parse_thumbnail_specs,
+    patch_slicer_metadata,
     render_stl_to_png,
 )
 
@@ -145,11 +154,11 @@ class TestBuildThumbnailBlock:
         assert comp == _COMP_NONE
         assert size == len(png)
 
-        # Params: width(2) + height(2) + format(2) = 6 bytes
-        w, h, fmt = struct.unpack_from("<HHH", block, 8)
+        # Params per bgcode spec: format(2) + width(2) + height(2) = 6 bytes
+        fmt, w, h = struct.unpack_from("<HHH", block, 8)
+        assert fmt == _IMG_PNG
         assert w == 16
         assert h == 16
-        assert fmt == _IMG_PNG
 
         # Payload
         payload = block[14 : 14 + len(png)]
@@ -171,8 +180,8 @@ class TestBuildThumbnailBlock:
         png = _make_png_bytes(100, 80)
         block = build_thumbnail_block(png, 100, 80)
 
-        w, h, fmt = struct.unpack_from("<HHH", block, 8)
-        assert (w, h, fmt) == (100, 80, _IMG_PNG)
+        fmt, w, h = struct.unpack_from("<HHH", block, 8)
+        assert (fmt, w, h) == (_IMG_PNG, 100, 80)
 
 
 # ---------------------------------------------------------------------------
@@ -331,20 +340,57 @@ class TestInjectThumbnails:
         assert len(gf.thumbnails) == 0
 
     @patch("filament_calibrator.thumbnail.render_stl_to_png")
-    def test_prepends_before_existing_blocks(self, mock_render, tmp_path):
+    def test_inserts_after_metadata_blocks(self, mock_render, tmp_path):
         mock_render.return_value = _make_png_bytes(16, 16)
         stl = _make_stl_file(tmp_path)
 
         gf = self._make_gf("bgcode")
-        existing_block = b"existing_metadata_block"
-        gf._bgcode_nongcode_blocks.append(existing_block)
+        # Simulate PrusaSlicer block order: FILE_META, PRINTER_META,
+        # PRINT_META, SLICER_META.
+        file_meta = struct.pack("<HHI", _BLK_FILE_METADATA, 0, 4) + b"test" + b"\x00" * 4
+        printer_meta = struct.pack("<HHI", _BLK_PRINTER_METADATA, 0, 4) + b"meta" + b"\x00" * 4
+        print_meta = struct.pack("<HHI", _BLK_PRINT_METADATA, 0, 4) + b"prnt" + b"\x00" * 4
+        gf._bgcode_nongcode_blocks = [file_meta, printer_meta, print_meta]
 
         inject_thumbnails(gf, stl, "16x16/PNG")
 
-        assert len(gf._bgcode_nongcode_blocks) == 2
-        # Thumbnail block should come BEFORE the existing block.
-        assert gf._bgcode_nongcode_blocks[1] == existing_block
-        assert gf._bgcode_nongcode_blocks[0] != existing_block
+        assert len(gf._bgcode_nongcode_blocks) == 4
+        # Block order should be: FILE_META, PRINTER_META, THUMBNAIL, PRINT_META
+        types = [
+            struct.unpack_from("<H", b, 0)[0]
+            for b in gf._bgcode_nongcode_blocks
+        ]
+        assert types == [
+            _BLK_FILE_METADATA,
+            _BLK_PRINTER_METADATA,
+            _BLK_THUMBNAIL,
+            _BLK_PRINT_METADATA,
+        ]
+
+
+# ---------------------------------------------------------------------------
+# _find_thumbnail_insert_pos
+# ---------------------------------------------------------------------------
+
+
+class TestFindThumbnailInsertPos:
+    def _blk(self, btype: int) -> bytes:
+        return struct.pack("<HHI", btype, 0, 4) + b"data" + b"\x00" * 4
+
+    def test_empty_list(self):
+        assert _find_thumbnail_insert_pos([]) == 0
+
+    def test_after_file_and_printer_meta(self):
+        blocks = [self._blk(0), self._blk(3), self._blk(4), self._blk(2)]
+        assert _find_thumbnail_insert_pos(blocks) == 2
+
+    def test_only_print_meta(self):
+        blocks = [self._blk(4)]
+        assert _find_thumbnail_insert_pos(blocks) == 0
+
+    def test_only_file_meta(self):
+        blocks = [self._blk(0)]
+        assert _find_thumbnail_insert_pos(blocks) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -380,9 +426,250 @@ class TestRoundTrip:
         gf2 = gl.load(out_path)
         assert gf2.source_format == "bgcode"
         assert len(gf2.thumbnails) == 2
-        assert gf2.thumbnails[0].width == 16
-        assert gf2.thumbnails[0].height == 16
-        assert gf2.thumbnails[1].width == 220
-        assert gf2.thumbnails[1].height == 124
+        # After round-trip, verify raw params bytes match bgcode spec
+        # order (format, width, height).  gcode_lib's .width/.height
+        # properties interpret these in a different order, so we check
+        # the raw params directly.
+        fmt0, w0, h0 = struct.unpack_from("<HHH", gf2.thumbnails[0].params)
+        assert (fmt0, w0, h0) == (_IMG_PNG, 16, 16)
+        fmt1, w1, h1 = struct.unpack_from("<HHH", gf2.thumbnails[1].params)
+        assert (fmt1, w1, h1) == (_IMG_PNG, 220, 124)
         assert gf2.thumbnails[0].data == png16
         assert gf2.thumbnails[1].data == png220
+
+
+# ---------------------------------------------------------------------------
+# Helpers for slicer metadata tests
+# ---------------------------------------------------------------------------
+
+
+def _build_slicer_meta_block(text: str, *, compressed: bool = False) -> bytes:
+    """Build a SLICER_METADATA block from INI-style text."""
+    payload = text.encode("utf-8")
+    params = struct.pack("<H", 0)  # encoding = raw/utf8
+    if compressed:
+        comp_payload = zlib.compress(payload)
+        hdr = struct.pack("<HHI", _BLK_SLICER_METADATA, _COMP_DEFLATE, len(payload))
+        cs = struct.pack("<I", len(comp_payload))
+        body = hdr + cs + params + comp_payload
+    else:
+        hdr = struct.pack("<HHI", _BLK_SLICER_METADATA, _COMP_NONE, len(payload))
+        body = hdr + params + payload
+    crc = struct.pack("<I", zlib.crc32(body) & 0xFFFFFFFF)
+    return body + crc
+
+
+def _build_meta_block(btype: int, text: str = "data") -> bytes:
+    """Build a simple uncompressed metadata block of the given type."""
+    payload = text.encode("utf-8")
+    params = struct.pack("<H", 0)
+    hdr = struct.pack("<HHI", btype, _COMP_NONE, len(payload))
+    body = hdr + params + payload
+    crc = struct.pack("<I", zlib.crc32(body) & 0xFFFFFFFF)
+    return body + crc
+
+
+# ---------------------------------------------------------------------------
+# _find_slicer_meta_index
+# ---------------------------------------------------------------------------
+
+
+class TestFindSlicerMetaIndex:
+    def test_finds_slicer_meta(self):
+        blocks = [
+            _build_meta_block(_BLK_FILE_METADATA),
+            _build_meta_block(_BLK_PRINTER_METADATA),
+            _build_slicer_meta_block("key=val"),
+        ]
+        assert _find_slicer_meta_index(blocks) == 2
+
+    def test_no_slicer_meta(self):
+        blocks = [
+            _build_meta_block(_BLK_FILE_METADATA),
+            _build_meta_block(_BLK_PRINTER_METADATA),
+        ]
+        assert _find_slicer_meta_index(blocks) is None
+
+    def test_empty_blocks(self):
+        assert _find_slicer_meta_index([]) is None
+
+
+# ---------------------------------------------------------------------------
+# _rebuild_slicer_meta_block
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildSlicerMetaBlock:
+    def test_update_existing_key(self):
+        block = _build_slicer_meta_block("printer_settings_id=\nother=123\n")
+        new_block = _rebuild_slicer_meta_block(
+            block, {"printer_settings_id": "Prusa CORE One HF0.4 nozzle"}
+        )
+        # Decode the new payload.
+        _, comp, usize = struct.unpack_from("<HHI", new_block, 0)
+        assert comp == _COMP_NONE
+        text = new_block[10 : 10 + usize].decode("utf-8")
+        assert "printer_settings_id=Prusa CORE One HF0.4 nozzle" in text
+        assert "other=123" in text
+
+    def test_add_missing_key(self):
+        block = _build_slicer_meta_block("existing=value\n")
+        new_block = _rebuild_slicer_meta_block(
+            block, {"printer_settings_id": "Test Printer"}
+        )
+        _, _, usize = struct.unpack_from("<HHI", new_block, 0)
+        text = new_block[10 : 10 + usize].decode("utf-8")
+        assert "printer_settings_id=Test Printer" in text
+        assert "existing=value" in text
+
+    def test_does_not_match_substring_key(self):
+        block = _build_slicer_meta_block(
+            "physical_printer_settings_id=orig\nprinter_settings_id=\n"
+        )
+        new_block = _rebuild_slicer_meta_block(
+            block, {"printer_settings_id": "Patched"}
+        )
+        _, _, usize = struct.unpack_from("<HHI", new_block, 0)
+        text = new_block[10 : 10 + usize].decode("utf-8")
+        assert "physical_printer_settings_id=orig" in text
+        assert "printer_settings_id=Patched" in text
+
+    def test_deflate_compressed_block(self):
+        block = _build_slicer_meta_block(
+            "printer_settings_id=\n", compressed=True
+        )
+        new_block = _rebuild_slicer_meta_block(
+            block, {"printer_settings_id": "Compressed Printer"}
+        )
+        # Verify it's still deflate.
+        _, comp, usize = struct.unpack_from("<HHI", new_block, 0)
+        assert comp == _COMP_DEFLATE
+        cs = struct.unpack_from("<I", new_block, 8)[0]
+        compressed = new_block[14 : 14 + cs]
+        text = zlib.decompress(compressed).decode("utf-8")
+        assert "printer_settings_id=Compressed Printer" in text
+
+    def test_unknown_compression_returns_unchanged(self):
+        # Build a block with comp=2 (heatshrink — unsupported).
+        payload = b"printer_settings_id=\n"
+        params = struct.pack("<H", 0)
+        hdr = struct.pack("<HHI", _BLK_SLICER_METADATA, 2, len(payload))
+        body = hdr + params + payload
+        crc = struct.pack("<I", zlib.crc32(body) & 0xFFFFFFFF)
+        block = body + crc
+        result = _rebuild_slicer_meta_block(block, {"printer_settings_id": "X"})
+        assert result == block
+
+    def test_crc_valid_after_rebuild(self):
+        block = _build_slicer_meta_block("printer_settings_id=\n")
+        new_block = _rebuild_slicer_meta_block(
+            block, {"printer_settings_id": "CRC Test"}
+        )
+        stored_crc = struct.unpack_from("<I", new_block, len(new_block) - 4)[0]
+        computed_crc = zlib.crc32(new_block[:-4]) & 0xFFFFFFFF
+        assert stored_crc == computed_crc
+
+
+# ---------------------------------------------------------------------------
+# patch_slicer_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestPatchSlicerMetadata:
+    def _make_gf(self, source_format="bgcode", slicer_text="printer_settings_id=\n"):
+        gf = gl.GCodeFile(
+            lines=[],
+            thumbnails=[],
+            source_format=source_format,
+        )
+        if source_format == "bgcode":
+            gf._bgcode_file_hdr = b"GCDE" + struct.pack("<I", 1) + struct.pack("<H", 1)
+            gf._bgcode_nongcode_blocks = [
+                _build_meta_block(_BLK_FILE_METADATA),
+                _build_meta_block(_BLK_PRINTER_METADATA),
+                _build_slicer_meta_block(slicer_text),
+            ]
+        return gf
+
+    def test_patches_coreone_04(self):
+        gf = self._make_gf()
+        patch_slicer_metadata(gf, "COREONE", 0.4)
+        block = gf._bgcode_nongcode_blocks[2]
+        _, _, usize = struct.unpack_from("<HHI", block, 0)
+        text = block[10 : 10 + usize].decode("utf-8")
+        assert "printer_settings_id=Prusa CORE One HF0.4 nozzle" in text
+
+    def test_patches_coreone_025(self):
+        gf = self._make_gf()
+        patch_slicer_metadata(gf, "COREONE", 0.25)
+        block = gf._bgcode_nongcode_blocks[2]
+        _, _, usize = struct.unpack_from("<HHI", block, 0)
+        text = block[10 : 10 + usize].decode("utf-8")
+        assert "printer_settings_id=Prusa CORE One 0.25 nozzle" in text
+
+    def test_skips_ascii_gcode(self):
+        gf = self._make_gf("text")
+        patch_slicer_metadata(gf, "COREONE", 0.4)
+        # No crash — just returns silently.
+
+    def test_skips_unknown_printer(self, capsys):
+        gf = self._make_gf()
+        patch_slicer_metadata(gf, "UNKNOWN", 0.4, verbose=True)
+        captured = capsys.readouterr()
+        assert "No printer_settings_id mapping" in captured.out
+
+    def test_skips_unknown_nozzle(self, capsys):
+        gf = self._make_gf()
+        patch_slicer_metadata(gf, "COREONE", 0.35, verbose=True)
+        captured = capsys.readouterr()
+        assert "No printer_settings_id mapping" in captured.out
+
+    def test_skips_empty_blocks(self):
+        gf = self._make_gf()
+        gf._bgcode_nongcode_blocks = []
+        patch_slicer_metadata(gf, "COREONE", 0.4)
+        # No crash — just returns.
+
+    def test_skips_no_slicer_meta_block(self):
+        gf = self._make_gf()
+        gf._bgcode_nongcode_blocks = [
+            _build_meta_block(_BLK_FILE_METADATA),
+        ]
+        patch_slicer_metadata(gf, "COREONE", 0.4)
+        # No crash — returns when _find_slicer_meta_index returns None.
+
+    def test_verbose_output(self, capsys):
+        gf = self._make_gf()
+        patch_slicer_metadata(gf, "COREONE", 0.4, verbose=True)
+        captured = capsys.readouterr()
+        assert "Patched printer_settings_id=" in captured.out
+
+    def test_failure_warns(self):
+        gf = self._make_gf()
+        # Corrupt the slicer block: declare deflate compression but provide
+        # invalid compressed data to trigger a zlib.error inside _rebuild.
+        gf._bgcode_nongcode_blocks[2] = (
+            struct.pack("<HHI", _BLK_SLICER_METADATA, _COMP_DEFLATE, 10)
+            + struct.pack("<I", 3)          # compressed_size = 3
+            + struct.pack("<H", 0)          # params
+            + b"\xff\xff\xff"               # invalid compressed data
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            patch_slicer_metadata(gf, "COREONE", 0.4)
+            assert len(w) == 1
+            assert "Slicer metadata patch failed" in str(w[0].message)
+
+    def test_does_not_corrupt_physical_printer_settings_id(self):
+        gf = self._make_gf(
+            slicer_text=(
+                "physical_printer_settings_id=My Printer\n"
+                "printer_settings_id=\n"
+            )
+        )
+        patch_slicer_metadata(gf, "COREONE", 0.6)
+        block = gf._bgcode_nongcode_blocks[2]
+        _, _, usize = struct.unpack_from("<HHI", block, 0)
+        text = block[10 : 10 + usize].decode("utf-8")
+        assert "physical_printer_settings_id=My Printer" in text
+        assert "printer_settings_id=Prusa CORE One HF0.6 nozzle" in text


### PR DESCRIPTION
## Summary

- **Pressure-advance calibration tool** (`pressure-advance` CLI): generates a hollow rectangular tower, slices it, and inserts PA/Linear Advance commands at each height level to find the optimal pressure advance value. Supports Prusa CORE One and Klipper-style printers with printer-specific start/end G-code.
- **Thumbnail injection**: renders STL models to PNG via VTK off-screen rendering and injects them as bgcode thumbnail blocks for print preview on printer LCDs.
- **Printer metadata patching**: patches `printer_settings_id` in bgcode SLICER_METADATA blocks so PrusaSlicer G-code Viewer loads the correct printer bed model.
- **`--nozzle-size` parameter** for all three tools with auto-derived layer height and extrusion width.
- **`--printer` / `--printer-model` flag** across all CLIs for printer-specific G-code and metadata.

## New files

- `pa_cli.py`, `pa_model.py`, `pa_insert.py` — PA calibration pipeline
- `printer_gcode.py` — printer-specific start/end G-code templates
- `thumbnail.py` — STL rendering, thumbnail block building, metadata patching

## Test plan

- [x] 489 tests pass with 100% statement coverage across all 15 source files
- [x] Generated sample bgcode files with thumbnails visible in PrusaSlicer G-code Viewer
- [x] Verified printer_settings_id patching loads correct bed model in Viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)