### PR TITLE
docs: update CLI references for --printer flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ src/filament_calibrator/
   pa_model.py       # CadQuery parametric hollow rectangular tower model
   pa_insert.py      # G-code pressure advance command insertion
   printer_gcode.py  # Printer-specific start/end G-code templates and rendering
-  thumbnail.py      # STL → PNG rendering (VTK) and bgcode thumbnail injection
+  thumbnail.py      # STL → PNG rendering (VTK), bgcode thumbnail injection,
+                    #   and slicer metadata patching (printer_settings_id)
 ```
 
 ### Key Dependencies
@@ -52,20 +53,20 @@ src/filament_calibrator/
 
 **temperature-tower** (`cli.run()`):
 load_config → apply_config → resolve_preset → generate_tower_stl →
-slice_tower → load G-code → inject_thumbnails → insert_temperatures →
-save → optional upload.
+slice_tower → load G-code → inject_thumbnails → patch_slicer_metadata →
+insert_temperatures → save → optional upload.
 
 **volumetric-flow** (`flow_cli.run()`):
 load_config → apply_config → validate_flow_args → resolve_preset →
 generate_flow_specimen_stl → slice_flow_specimen (vase mode) → load G-code →
-inject_thumbnails → compute_flow_levels → insert_flow_rates → save →
-optional upload.
+inject_thumbnails → patch_slicer_metadata → compute_flow_levels →
+insert_flow_rates → save → optional upload.
 
 **pressure-advance** (`pa_cli.run()`):
 load_config → apply_config → validate_pa_args → resolve_preset →
 generate_pa_tower_stl → slice_pa_specimen → load G-code →
-inject_thumbnails → compute_pa_levels → insert_pa_commands → save →
-optional upload.
+inject_thumbnails → patch_slicer_metadata → compute_pa_levels →
+insert_pa_commands → save → optional upload.
 
 ### Filament Preset System
 

--- a/README.md
+++ b/README.md
@@ -219,8 +219,12 @@ must be evenly divisible by `--temp-step`.
 | `--fan-speed` | from preset | Fan speed (0--100%) |
 | `--config-ini` | | PrusaSlicer `.ini` config file |
 | `--prusaslicer-path` | auto-detect | Path to PrusaSlicer executable |
-| `--bed-center` | `125,105` | Bed centre as X,Y in mm |
+| `--printer` | `COREONE` | Printer model — auto-sets bed center/shape, generates start/end G-code, and embeds printer metadata in bgcode |
+| `--bed-center` | from `--printer` | Bed centre as X,Y in mm (auto-set by `--printer`) |
 | `--extra-slicer-args` | | Additional PrusaSlicer CLI args (must be last) |
+
+Supported printers for `--printer`: **COREONE**, **COREONEL**, **MK4S**
+(alias: MK4), **MINI**, **XL**.
 
 #### Printer Options
 
@@ -360,8 +364,12 @@ of levels cannot exceed 50.
 | `--extrusion-width` | from `--nozzle-size` | Slicer extrusion width in mm (default: nozzle × 1.125) |
 | `--config-ini` | | PrusaSlicer `.ini` config file |
 | `--prusaslicer-path` | auto-detect | Path to PrusaSlicer executable |
-| `--bed-center` | `125,105` | Bed centre as X,Y in mm |
+| `--printer` | `COREONE` | Printer model — auto-sets bed center/shape and embeds printer metadata in bgcode |
+| `--bed-center` | from `--printer` | Bed centre as X,Y in mm (auto-set by `--printer`) |
 | `--extra-slicer-args` | | Additional PrusaSlicer CLI args (must be last) |
+
+Supported printers for `--printer`: **COREONE**, **COREONEL**, **MK4S**
+(alias: MK4), **MINI**, **XL**.
 
 #### Printer Options
 
@@ -506,8 +514,8 @@ of levels cannot exceed 50. `--start-pa` must be non-negative.
 | `--extrusion-width` | from `--nozzle-size` | Slicer extrusion width in mm (default: nozzle × 1.125) |
 | `--config-ini` | | PrusaSlicer `.ini` config file |
 | `--prusaslicer-path` | auto-detect | Path to PrusaSlicer executable |
-| `--printer` | `COREONE` | Printer model for start/end G-code (see below) |
-| `--bed-center` | `125,105` | Bed centre as X,Y in mm (auto-set by `--printer`) |
+| `--printer` | `COREONE` | Printer model — generates start/end G-code, auto-sets bed center/shape, and embeds printer metadata in bgcode (see below) |
+| `--bed-center` | from `--printer` | Bed centre as X,Y in mm (auto-set by `--printer`) |
 | `--extra-slicer-args` | | Additional PrusaSlicer CLI args (must be last) |
 
 #### Printer-Specific Start/End G-code


### PR DESCRIPTION
## Summary

- Add `--printer` flag to temperature-tower and volumetric-flow CLI reference tables in README (was only documented for pressure-advance)
- Update `--bed-center` default from `125,105` to `from --printer` across all three tools
- Add `patch_slicer_metadata` step to all pipeline flows in CLAUDE.md
- Update `thumbnail.py` description to mention slicer metadata patching

🤖 Generated with [Claude Code](https://claude.com/claude-code)