### PR TITLE
feat: improve PA chevron pattern geometry and labels

### DIFF
--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -206,8 +206,9 @@ def build_pa_namespace(
     arm_length: float = 40.0,
     wall_count: int = 3,
     num_layers: int = 4,
+    frame_layers: int = 1,
     pattern_spacing: float = 1.6,
-    frame_offset: float = 3.0,
+    frame_offset: float = 0.0,
     printer: str,
     ascii_gcode: bool,
     output_dir: str,
@@ -236,6 +237,7 @@ def build_pa_namespace(
         arm_length=arm_length,
         wall_count=wall_count,
         num_layers=num_layers,
+        frame_layers=frame_layers,
         pattern_spacing=pattern_spacing,
         frame_offset=frame_offset,
         printer=printer,
@@ -1302,8 +1304,9 @@ def _app() -> None:  # pragma: no cover
         pa_arm_length = 40.0
         pa_wall_count = 3
         pa_num_layers = 4
+        pa_frame_layers = 1
         pa_pattern_spacing = 1.6
-        pa_frame_offset = 3.0
+        pa_frame_offset = 0.0
         if method_key == "pattern":
             with st.expander("Pattern Settings"):
                 pa_corner_angle = st.number_input(
@@ -1335,6 +1338,13 @@ def _app() -> None:  # pragma: no cover
                     max_value=20,
                     key="pa_num_layers",
                 )
+                pa_frame_layers = st.number_input(
+                    "Frame Layers",
+                    value=1,
+                    min_value=1,
+                    max_value=10,
+                    key="pa_frame_layers",
+                )
                 pa_pattern_spacing = st.number_input(
                     "Pattern Spacing (mm)",
                     value=1.6,
@@ -1344,7 +1354,7 @@ def _app() -> None:  # pragma: no cover
                 )
                 pa_frame_offset = st.number_input(
                     "Frame Offset (mm)",
-                    value=3.0,
+                    value=0.0,
                     min_value=0.0,
                     step=0.5,
                     key="pa_frame_offset",
@@ -1404,6 +1414,7 @@ def _app() -> None:  # pragma: no cover
                 arm_length=pa_arm_length,
                 wall_count=pa_wall_count,
                 num_layers=pa_num_layers,
+                frame_layers=pa_frame_layers,
                 pattern_spacing=pa_pattern_spacing,
                 frame_offset=pa_frame_offset,
                 printer=printer,

--- a/src/filament_calibrator/pa_cli.py
+++ b/src/filament_calibrator/pa_cli.py
@@ -40,6 +40,7 @@ from filament_calibrator.pa_model import (
 from filament_calibrator.pa_pattern import (
     DEFAULT_ARM_LENGTH,
     DEFAULT_CORNER_ANGLE,
+    DEFAULT_FRAME_NUM_LAYERS,
     DEFAULT_FRAME_OFFSET,
     DEFAULT_NUM_LAYERS,
     DEFAULT_PATTERN_SPACING,
@@ -136,6 +137,10 @@ def build_parser() -> argparse.ArgumentParser:
     pat.add_argument(
         "--num-layers", type=int, default=DEFAULT_NUM_LAYERS,
         help=f"Number of layers to print. Default: {DEFAULT_NUM_LAYERS}",
+    )
+    pat.add_argument(
+        "--frame-layers", type=int, default=DEFAULT_FRAME_NUM_LAYERS,
+        help=f"Number of layers for the frame/border. Default: {DEFAULT_FRAME_NUM_LAYERS}",
     )
     pat.add_argument(
         "--pattern-spacing", type=float, default=DEFAULT_PATTERN_SPACING,
@@ -617,6 +622,7 @@ def _run_pattern_pipeline(
         pattern_spacing=args.pattern_spacing,
         wall_thickness=DEFAULT_WALL_THICKNESS,
         frame_offset=args.frame_offset,
+        frame_num_layers=args.frame_layers,
         layer_height=layer_height,
         filament_type=args.filament_type,
     )

--- a/src/filament_calibrator/pa_pattern.py
+++ b/src/filament_calibrator/pa_pattern.py
@@ -42,11 +42,25 @@ Defaults to ``DEFAULT_WALL_THICKNESS`` so the gap matches the line width.
 DEFAULT_WALL_THICKNESS: float = 1.6
 """Cross-section thickness of each chevron arm in mm."""
 
-DEFAULT_FRAME_OFFSET: float = 3.0
-"""Margin between outermost chevron arm and inner frame edge in mm."""
+DEFAULT_FRAME_OFFSET: float = 0.0
+"""Margin between outermost chevron arm edge and frame outer edge.
 
-DEFAULT_LABEL_HEIGHT: float = 10.0
+At ``0.0`` the frame outer edge is flush with the arm endpoints so
+the chevron arms extend to the outer border.
+"""
+
+DEFAULT_FRAME_NUM_LAYERS: int = 1
+"""Number of printed layers for the rectangular frame/border."""
+
+DEFAULT_LABEL_HEIGHT: float = 14.0
 """Height of the label strip placed above the frame in mm."""
+
+DEFAULT_CHEVRON_X_INSET: float = 2.0
+"""Horizontal inset of chevron arm endpoints from the left frame edge in mm.
+
+Shifts all chevron tips to the right so the outermost arm endpoints
+do not touch the left frame wall.
+"""
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +93,7 @@ class PAPatternConfig:
     pattern_spacing: float = DEFAULT_PATTERN_SPACING
     wall_thickness: float = DEFAULT_WALL_THICKNESS
     frame_offset: float = DEFAULT_FRAME_OFFSET
+    frame_num_layers: int = DEFAULT_FRAME_NUM_LAYERS
     layer_height: float = 0.2
     filament_type: str = "PLA"
 
@@ -107,8 +122,13 @@ def chevron_y_extent(arm_length: float, corner_angle: float) -> float:
 
 
 def total_height(config: PAPatternConfig) -> float:
-    """Total Z height of the printed pattern."""
+    """Total Z height of the printed chevrons."""
     return config.num_layers * config.layer_height
+
+
+def frame_height(config: PAPatternConfig) -> float:
+    """Z height of the rectangular frame/border."""
+    return config.frame_num_layers * config.layer_height
 
 
 def tip_spacing(config: PAPatternConfig) -> float:
@@ -299,8 +319,15 @@ def _make_labels(
     x_tips: List[float],
     pa_values: List[float],
     height: float,
+    *,
+    frame_x_tips: Optional[List[float]] = None,
 ) -> cq.Workplane:
-    """Create the label strip with embossed PA values above the frame."""
+    """Create the label strip with embossed PA values above the frame.
+
+    *x_tips* positions the text labels.  If *frame_x_tips* is given, the
+    label-strip bar is sized from those tips instead (so the bar matches a
+    frame that may be wider than the chevron positions).
+    """
     half = math.radians(config.corner_angle / 2)
     _, frame_top = pattern_y_bounds(config)
 
@@ -309,7 +336,8 @@ def _make_labels(
     bar_cy = frame_top + label_strip_height / 2.0
 
     # Bar spans the full frame width.
-    bar_x_min, bar_x_max = pattern_x_bounds(config, x_tips)
+    bar_tips = frame_x_tips if frame_x_tips is not None else x_tips
+    bar_x_min, bar_x_max = pattern_x_bounds(config, bar_tips)
     bar_width = bar_x_max - bar_x_min
     bar_cx = (bar_x_min + bar_x_max) / 2.0
 
@@ -325,7 +353,8 @@ def _make_labels(
     # the top of the frame), not at the tip X.
     arm_end_dx = config.arm_length * math.cos(half)
     label_depth = config.layer_height  # one layer raised
-    font_size = min(3.0, label_strip_height * 0.35)
+    font_size = min(4.0, label_strip_height * 0.25)
+    label_y = bar_cy  # centre text in label strip
     result = bar
     for tx, pa in zip(x_tips, pa_values):
         label_x = tx - arm_end_dx
@@ -333,7 +362,7 @@ def _make_labels(
         text_solid = (
             cq.Workplane("XY")
             .workplane(offset=height)
-            .center(label_x, bar_cy)
+            .center(label_x, label_y)
             .transformed(rotate=(0, 0, 90))
             .text(
                 label_text, font_size, label_depth,
@@ -358,25 +387,36 @@ def generate_pa_pattern_stl(
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
     height = total_height(config)
+    f_height = frame_height(config)
     x_tips = pattern_x_tips(config)
 
-    # Build chevrons.
+    # Shift chevrons to the right so arm endpoints don't touch the left
+    # frame wall.  The frame keeps its original left boundary.
+    inset = DEFAULT_CHEVRON_X_INSET
+    shifted = [round(x + inset, 4) for x in x_tips]
+
+    # Frame tips: original leftmost (left boundary) + shifted (right boundary).
+    frame_tips = [x_tips[0]] + shifted
+
+    # Build chevrons at shifted positions.
     result: cq.Workplane | None = None
-    for tx in x_tips:
+    for tx in shifted:
         chevron = _make_chevron(tx, config, height)
         if result is None:
             result = chevron
         else:
             result = result.union(chevron)
 
-    # Add frame.
-    frame = _make_frame(config, x_tips, height)
+    # Add frame (may be shorter than chevrons).
+    frame = _make_frame(config, frame_tips, f_height)
     result = result.union(frame)
 
     # Add labels if PA values are provided.
-    if pa_values is not None and len(pa_values) == len(x_tips):
-        labels = _make_labels(config, x_tips, pa_values, height)
+    if pa_values is not None and len(pa_values) == len(shifted):
+        labels = _make_labels(
+            config, shifted, pa_values, height, frame_x_tips=frame_tips,
+        )
         result = result.union(labels)
 
     cq.exporters.export(result, output_path, exportType="STL")
-    return output_path, x_tips
+    return output_path, shifted

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -280,9 +280,10 @@ class TestBuildPaNamespace:
         assert ns.level_height == 1.0
         assert ns.corner_angle == 90.0
         assert ns.arm_length == 40.0
-        assert ns.frame_offset == 3.0
+        assert ns.frame_offset == 0.0
         assert ns.wall_count == 3
         assert ns.num_layers == 4
+        assert ns.frame_layers == 1
         assert ns.pattern_spacing == 1.6
 
     def test_method_pattern(self) -> None:
@@ -304,6 +305,7 @@ class TestBuildPaNamespace:
             frame_offset=5.0,
             wall_count=5,
             num_layers=8,
+            frame_layers=2,
             pattern_spacing=3.0,
             printer="MK4S",
             ascii_gcode=True,
@@ -321,6 +323,7 @@ class TestBuildPaNamespace:
         assert ns.frame_offset == 5.0
         assert ns.wall_count == 5
         assert ns.num_layers == 8
+        assert ns.frame_layers == 2
         assert ns.pattern_spacing == 3.0
         assert ns.level_height == 2.0
         assert ns.ascii_gcode is True

--- a/tests/test_pa_cli.py
+++ b/tests/test_pa_cli.py
@@ -132,9 +132,10 @@ class TestBuildParser:
         args = p.parse_args(["--start-pa", "0", "--end-pa", "0.1", "--pa-step", "0.01"])
         assert args.corner_angle == 90.0
         assert args.arm_length == 40.0
-        assert args.frame_offset == 3.0
+        assert args.frame_offset == 0.0
         assert args.wall_count == 3
         assert args.num_layers == 4
+        assert args.frame_layers == 1
         assert args.pattern_spacing == 1.6
 
     def test_pattern_options_custom(self):
@@ -147,6 +148,7 @@ class TestBuildParser:
             "--frame-offset", "5",
             "--wall-count", "5",
             "--num-layers", "8",
+            "--frame-layers", "2",
             "--pattern-spacing", "3",
         ])
         assert args.corner_angle == 60.0
@@ -154,6 +156,7 @@ class TestBuildParser:
         assert args.frame_offset == 5.0
         assert args.wall_count == 5
         assert args.num_layers == 8
+        assert args.frame_layers == 2
         assert args.pattern_spacing == 3.0
 
     def test_filament_type_help_lists_presets(self):
@@ -274,8 +277,8 @@ class TestRun:
             ascii_gcode=False,
             config=None, verbose=False,
             # Pattern-specific defaults (used when method="pattern")
-            corner_angle=90.0, arm_length=40.0, frame_offset=3.0,
-            wall_count=3, num_layers=4, pattern_spacing=1.6,
+            corner_angle=90.0, arm_length=40.0, frame_offset=0.0,
+            wall_count=3, num_layers=4, frame_layers=1, pattern_spacing=1.6,
         )
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
@@ -1158,8 +1161,8 @@ class TestRunPattern:
             output_dir=str(tmp_path), keep_files=False,
             ascii_gcode=False,
             config=None, verbose=False,
-            corner_angle=90.0, arm_length=40.0, frame_offset=3.0,
-            wall_count=3, num_layers=4, pattern_spacing=1.6,
+            corner_angle=90.0, arm_length=40.0, frame_offset=0.0,
+            wall_count=3, num_layers=4, frame_layers=1, pattern_spacing=1.6,
         )
         defaults.update(overrides)
         return argparse.Namespace(**defaults)

--- a/tests/test_pa_pattern.py
+++ b/tests/test_pa_pattern.py
@@ -9,6 +9,8 @@ import pytest
 from filament_calibrator.pa_pattern import (
     DEFAULT_ARM_LENGTH,
     DEFAULT_CORNER_ANGLE,
+    DEFAULT_CHEVRON_X_INSET,
+    DEFAULT_FRAME_NUM_LAYERS,
     DEFAULT_FRAME_OFFSET,
     DEFAULT_LABEL_HEIGHT,
     DEFAULT_NUM_LAYERS,
@@ -22,6 +24,7 @@ from filament_calibrator.pa_pattern import (
     _make_labels,
     chevron_x_extent,
     chevron_y_extent,
+    frame_height,
     generate_pa_pattern_stl,
     pattern_x_bounds,
     pattern_x_tips,
@@ -55,10 +58,16 @@ class TestConstants:
         assert DEFAULT_WALL_THICKNESS == 1.6
 
     def test_frame_offset(self):
-        assert DEFAULT_FRAME_OFFSET == 3.0
+        assert DEFAULT_FRAME_OFFSET == 0.0
+
+    def test_frame_num_layers(self):
+        assert DEFAULT_FRAME_NUM_LAYERS == 1
 
     def test_label_height(self):
-        assert DEFAULT_LABEL_HEIGHT == 10.0
+        assert DEFAULT_LABEL_HEIGHT == 14.0
+
+    def test_chevron_x_inset(self):
+        assert DEFAULT_CHEVRON_X_INSET == 2.0
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +85,8 @@ class TestPAPatternConfig:
         assert cfg.num_layers == 4
         assert cfg.pattern_spacing == 1.6
         assert cfg.wall_thickness == 1.6
-        assert cfg.frame_offset == 3.0
+        assert cfg.frame_offset == 0.0
+        assert cfg.frame_num_layers == 1
         assert cfg.layer_height == 0.2
         assert cfg.filament_type == "PLA"
 
@@ -90,6 +100,7 @@ class TestPAPatternConfig:
             pattern_spacing=3.0,
             wall_thickness=2.0,
             frame_offset=5.0,
+            frame_num_layers=2,
             layer_height=0.1,
             filament_type="PETG",
         )
@@ -101,6 +112,7 @@ class TestPAPatternConfig:
         assert cfg.pattern_spacing == 3.0
         assert cfg.wall_thickness == 2.0
         assert cfg.frame_offset == 5.0
+        assert cfg.frame_num_layers == 2
         assert cfg.layer_height == 0.1
         assert cfg.filament_type == "PETG"
 
@@ -148,6 +160,16 @@ class TestTotalHeight:
     def test_custom(self):
         cfg = PAPatternConfig(num_patterns=3, num_layers=10, layer_height=0.1)
         assert total_height(cfg) == pytest.approx(1.0)
+
+
+class TestFrameHeight:
+    def test_default(self):
+        cfg = PAPatternConfig(num_patterns=3)
+        assert frame_height(cfg) == pytest.approx(1 * 0.2)
+
+    def test_custom(self):
+        cfg = PAPatternConfig(num_patterns=3, frame_num_layers=2, layer_height=0.3)
+        assert frame_height(cfg) == pytest.approx(0.6)
 
 
 # ---------------------------------------------------------------------------
@@ -582,7 +604,7 @@ class TestGeneratePaPatternStl:
 
         assert result_path == out_path
         assert len(x_tips) == 3
-        assert x_tips[1] == pytest.approx(0.0)
+        assert x_tips[1] == pytest.approx(DEFAULT_CHEVRON_X_INSET)
 
     @patch("filament_calibrator.pa_pattern.cq")
     def test_unions_multiple_chevrons_and_frame(self, mock_cq, tmp_path):


### PR DESCRIPTION
## Summary
- Add independent `frame_num_layers` config (default 1) so the border is 0.2mm while chevrons are 0.8mm (4 layers)
- Set `frame_offset` to 0.0 so chevron arms extend to the frame outer edge
- Shift chevrons 2mm right of the left frame via `DEFAULT_CHEVRON_X_INSET` for a clean gap
- Resize label strip to 14mm with centered 3.5mm embossed font
- Add `--frame-layers` CLI argument and Streamlit GUI widget
- Refactor `_make_labels` to accept `frame_x_tips` for independent bar sizing

## Test plan
- [x] 674 tests pass with 100% coverage
- [ ] Verify STL in PrusaSlicer: chevrons have 2mm gap from left frame, labels readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)