### PR TITLE
feat: add retraction calibration tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 **filament-calibrator** is a CLI tool suite for 3D printer filament calibration.
-It contains four tools:
+It contains five tools:
 
 - `temperature-tower` — generates, slices, and uploads temperature tower prints
   to find the optimal printing temperature for a filament.
@@ -22,6 +22,11 @@ It contains four tools:
     rectangular frame with embossed PA value labels; each chevron is
     printed at a different PA value — inspect which has the sharpest
     corners.  PA insertion is X-based (by chevron tip position).
+- `retraction-test` — generates two cylindrical towers spaced apart;
+  PrusaSlicer's travel moves between them trigger retraction.  At each
+  height level the firmware retraction length is changed via
+  `M207 S<length>`, so the user can inspect stringing at each height to
+  find the optimal retraction distance.
 
 ## Architecture
 
@@ -35,7 +40,8 @@ src/filament_calibrator/
   config.py         # TOML config file loading
   model.py          # CadQuery parametric temperature tower model
   slicer.py         # PrusaSlicer CLI wrapper (slice_tower, slice_flow_specimen,
-                    #   slice_pa_specimen, slice_em_specimen)
+                    #   slice_pa_specimen, slice_em_specimen,
+                    #   slice_retraction_specimen)
   tempinsert.py     # G-code temperature command insertion
   em_cli.py         # extrusion-multiplier argparse CLI, pipeline orchestration
   em_model.py       # CadQuery parametric cube model for EM calibration
@@ -50,7 +56,10 @@ src/filament_calibrator/
   ini_writer.py     # Merge calibration results into PrusaSlicer .ini configs;
                     #   helpers (replace_ini_value, pa_command,
                     #   inject_pa_into_start_gcode) imported from gcode-lib
-  gui.py            # Streamlit browser GUI wrapping all four CLIs
+  retraction_cli.py   # retraction-test argparse CLI, pipeline orchestration
+  retraction_model.py # CadQuery parametric two-tower retraction test model
+  retraction_insert.py # G-code M207 retraction length command insertion
+  gui.py            # Streamlit browser GUI wrapping all five CLIs
 ```
 
 ### Key Dependencies
@@ -98,9 +107,16 @@ slice_em_specimen (vase mode, classic walls) → load G-code →
 inject_thumbnails → patch_slicer_metadata → save →
 print expected wall thickness → optional upload.
 
+**retraction-test** (`retraction_cli.run()`):
+load_config → apply_config → validate_retraction_args → resolve_preset →
+generate_retraction_tower_stl → slice_retraction_specimen
+(firmware retraction) → load G-code → inject_thumbnails →
+patch_slicer_metadata → compute_retraction_levels →
+insert_retraction_commands (M207) → save → optional upload.
+
 ### Filament Preset System
 
-All four CLIs use `--filament-type` to look up defaults from
+All five CLIs use `--filament-type` to look up defaults from
 `gcode_lib.FILAMENT_PRESETS`.  Known presets (PLA, PETG, ABS, ASA, TPU, etc.)
 automatically set nozzle temperature, bed temperature, and fan speed.
 Explicit CLI arguments (`--nozzle-temp`, `--bed-temp`, `--fan-speed`)
@@ -128,6 +144,11 @@ override the preset.  Unknown filament names fall back to safe defaults
   no infill, 5mm brim).  `slice_em_specimen()` always forces
   `--spiral-vase`, `--perimeter-generator=classic`, and
   `--support-material=0`.
+- `RETRACTION_SLICER_ARGS` — for retraction test tower slicing
+  (2 perimeters, 15% infill).  `slice_retraction_specimen()` always
+  forces `--use-firmware-retraction` so PrusaSlicer emits G10/G11
+  instead of explicit retract moves, allowing M207 commands to control
+  the retraction length.
 
 All slicer functions accept `nozzle_diameter` to pass `--nozzle-diameter` to
 PrusaSlicer, and pass `--center` and `--bed-shape` for Prusa MK-series bed
@@ -151,7 +172,8 @@ thumbnail previews.  Use `--ascii-gcode` on the CLI to switch to text
 - Filament preset lookup is case-insensitive (`.upper()`)
 - Shared CLI helpers (`_apply_config`, `_resolve_output_dir`, `_UNSET`,
   `_KNOWN_TYPES`, `_ARGPARSE_DEFAULTS`) live in `cli.py` and are imported
-  by `em_cli.py`, `flow_cli.py`, and `pa_cli.py`.  Generic filename/preset
+  by `em_cli.py`, `flow_cli.py`, `pa_cli.py`, and `retraction_cli.py`.
+  Generic filename/preset
   helpers (`unique_suffix`, `safe_filename_part`, `gcode_ext`,
   `resolve_filament_preset`) are imported from `gcode_lib`.
 
@@ -180,6 +202,7 @@ Entry points:
 - `extrusion-multiplier` → `filament_calibrator.em_cli:main`
 - `volumetric-flow` → `filament_calibrator.flow_cli:main`
 - `pressure-advance` → `filament_calibrator.pa_cli:main`
+- `retraction-test` → `filament_calibrator.retraction_cli:main`
 - `filament-calibrator-gui` → `filament_calibrator.gui:main` (requires `[gui]` extra)
 
 ## Common Tasks
@@ -196,9 +219,13 @@ Entry points:
   (DEFAULT_CORNER_ANGLE, DEFAULT_ARM_LENGTH, DEFAULT_WALL_THICKNESS,
   DEFAULT_PATTERN_SPACING, DEFAULT_FRAME_OFFSET, DEFAULT_LABEL_HEIGHT).
 - **Change EM cube geometry**: Edit `CUBE_SIZE` in `em_model.py`.
+- **Change retraction tower geometry**: Edit constants in
+  `retraction_model.py` (TOWER_DIAMETER, TOWER_SPACING, BASE_LENGTH,
+  BASE_WIDTH, BASE_HEIGHT, LEVEL_HEIGHT).
 - **Change slicer defaults**: Edit `DEFAULT_SLICER_ARGS` (temp tower),
   `VASE_MODE_SLICER_ARGS` (flow specimen), `PA_SLICER_ARGS` (PA tower),
-  or `EM_SLICER_ARGS` (EM cube) in `slicer.py`.
+  `EM_SLICER_ARGS` (EM cube), or `RETRACTION_SLICER_ARGS` (retraction
+  towers) in `slicer.py`.
 - **Add a new calibration tool**: Create a new module + CLI entry point in
   `pyproject.toml [project.scripts]`.  Import shared helpers from `cli.py`.
 - **Add a new config key**: Add to `CONFIG_KEYS` in `config.py`, add

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ temperature-tower = "filament_calibrator.cli:main"
 extrusion-multiplier = "filament_calibrator.em_cli:main"
 volumetric-flow = "filament_calibrator.flow_cli:main"
 pressure-advance = "filament_calibrator.pa_cli:main"
+retraction-test = "filament_calibrator.retraction_cli:main"
 filament-calibrator-gui = "filament_calibrator.gui:main"
 
 [tool.hatch.build.targets.wheel]

--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -304,6 +304,59 @@ def build_em_namespace(
     )
 
 
+def build_retraction_namespace(
+    *,
+    filament_type: str,
+    start_retraction: float,
+    end_retraction: float,
+    retraction_step: float,
+    level_height: float = 1.0,
+    nozzle_temp: int,
+    bed_temp: int,
+    fan_speed: int,
+    nozzle_size: float,
+    layer_height: float,
+    extrusion_width: float,
+    printer: str,
+    ascii_gcode: bool,
+    output_dir: str,
+    config_ini: Optional[str],
+    prusaslicer_path: Optional[str],
+    printer_url: Optional[str],
+    api_key: Optional[str],
+    no_upload: bool,
+    print_after_upload: bool,
+) -> argparse.Namespace:
+    """Build an ``argparse.Namespace`` for the retraction-test pipeline."""
+    return argparse.Namespace(
+        filament_type=filament_type,
+        start_retraction=start_retraction,
+        end_retraction=end_retraction,
+        retraction_step=retraction_step,
+        level_height=level_height,
+        nozzle_temp=nozzle_temp,
+        bed_temp=bed_temp,
+        fan_speed=fan_speed,
+        nozzle_size=nozzle_size,
+        layer_height=layer_height,
+        extrusion_width=extrusion_width,
+        printer=printer,
+        ascii_gcode=ascii_gcode,
+        output_dir=output_dir,
+        config_ini=config_ini or None,
+        prusaslicer_path=prusaslicer_path or None,
+        bed_center=None,
+        extra_slicer_args=None,
+        printer_url=printer_url or None,
+        api_key=api_key or None,
+        no_upload=no_upload,
+        print_after_upload=print_after_upload,
+        config=None,
+        keep_files=True,
+        verbose=True,
+    )
+
+
 def _fresh_output_dir(custom_output_dir: str) -> str:
     """Return *custom_output_dir* if set, otherwise a fresh temp directory.
 

--- a/src/filament_calibrator/retraction_cli.py
+++ b/src/filament_calibrator/retraction_cli.py
@@ -1,0 +1,568 @@
+"""Retraction calibration CLI and pipeline orchestration.
+
+Generates a two-tower retraction test specimen, slices it with firmware
+retraction enabled, and inserts ``M207 S<length>`` commands at each height
+level so the user can inspect stringing between the towers to find the
+optimal retraction distance.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import gcode_lib as gl
+
+from filament_calibrator.cli import (
+    _ARGPARSE_DEFAULTS,
+    _KNOWN_TYPES,
+    _UNSET,
+    _apply_config,
+    _explicit_keys,
+    _resolve_output_dir,
+)
+from filament_calibrator.config import load_config
+from filament_calibrator.retraction_insert import (
+    compute_retraction_levels,
+    insert_retraction_commands,
+)
+from filament_calibrator.retraction_model import (
+    BASE_HEIGHT,
+    BASE_LENGTH,
+    BASE_WIDTH,
+    RetractionTowerConfig,
+    generate_retraction_tower_stl,
+)
+from filament_calibrator.slicer import (
+    DEFAULT_BED_CENTER,
+    DEFAULT_THUMBNAILS,
+    slice_retraction_specimen,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_LEVELS: int = 50
+"""Maximum number of retraction levels allowed."""
+
+_FIND_CONFIG_PATHS = (
+    Path("filament-calibrator.toml"),
+    Path.home() / ".config" / "filament-calibrator" / "config.toml",
+)
+
+
+def _find_config_path(explicit: Optional[str]) -> Optional[str]:
+    """Return the resolved config file path, or ``None``."""
+    if explicit is not None:
+        return explicit
+    for p in _FIND_CONFIG_PATHS:
+        if p.exists():
+            return str(p)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the ``retraction-test`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="retraction-test",
+        description=(
+            "Generate a retraction calibration two-tower print.  "
+            "Firmware retraction length (M207) is varied at each "
+            "height level so the user can inspect stringing between "
+            "the towers to find the optimal retraction distance."
+        ),
+    )
+
+    # -- Retraction options --
+    retract = parser.add_argument_group("retraction options")
+    retract.add_argument(
+        "--start-retraction", type=float, default=0.0,
+        help="Starting retraction length in mm (default: 0.0).",
+    )
+    retract.add_argument(
+        "--end-retraction", type=float, default=2.0,
+        help="Ending retraction length in mm (default: 2.0).",
+    )
+    retract.add_argument(
+        "--retraction-step", type=float, default=0.1,
+        help="Retraction length increment per level in mm (default: 0.1).",
+    )
+
+    # -- Model options --
+    model = parser.add_argument_group("model options")
+    model.add_argument(
+        "--level-height", type=float, default=1.0,
+        help="Height per retraction level in mm (default: 1.0).",
+    )
+    model.add_argument(
+        "--filament-type", type=str, default="PLA",
+        help=(
+            "Filament type for preset lookup.  Known types: "
+            + ", ".join(_KNOWN_TYPES) + "."
+        ),
+    )
+
+    # -- Nozzle options --
+    nozzle = parser.add_argument_group("nozzle options")
+    nozzle.add_argument(
+        "--nozzle-size", type=float, default=0.4,
+        help="Nozzle diameter in mm (default: 0.4).",
+    )
+
+    # -- Slicer options --
+    slicer = parser.add_argument_group("slicer options")
+    slicer.add_argument(
+        "--layer-height", type=float, default=_UNSET,
+        help="Slicer layer height in mm (default: nozzle × 0.5).",
+    )
+    slicer.add_argument(
+        "--extrusion-width", type=float, default=_UNSET,
+        help="Slicer extrusion width in mm (default: nozzle × 1.125).",
+    )
+    slicer.add_argument("--nozzle-temp", type=int, default=_UNSET)
+    slicer.add_argument("--bed-temp", type=int, default=_UNSET)
+    slicer.add_argument("--fan-speed", type=int, default=_UNSET)
+    slicer.add_argument("--config-ini", type=str, default=None)
+    slicer.add_argument("--prusaslicer-path", type=str, default=None)
+    slicer.add_argument("--bed-center", type=str, default=None)
+    slicer.add_argument(
+        "--extra-slicer-args", nargs="*", default=None,
+        help="Additional PrusaSlicer CLI arguments.",
+    )
+
+    # -- Printer model --
+    printer_group = parser.add_argument_group("printer model")
+    printer_group.add_argument(
+        "--printer", type=str, default="COREONE",
+        help="Printer model (default: COREONE).",
+    )
+
+    # -- Printer / upload --
+    upload = parser.add_argument_group("printer / upload")
+    upload.add_argument("--printer-url", type=str, default=None)
+    upload.add_argument("--api-key", type=str, default=None)
+    upload.add_argument(
+        "--no-upload", action="store_true", default=False,
+        help="Skip uploading to the printer.",
+    )
+    upload.add_argument(
+        "--print-after-upload", action="store_true", default=False,
+    )
+
+    # -- Config file --
+    parser.add_argument("--config", type=str, default=None)
+
+    # -- Output --
+    output = parser.add_argument_group("output options")
+    output.add_argument("--output-dir", type=str, default=None)
+    output.add_argument(
+        "--keep-files", action="store_true", default=False,
+        help="Keep intermediate STL and raw G-code files.",
+    )
+    output.add_argument(
+        "--ascii-gcode", action="store_true", default=False,
+        help="Output text .gcode instead of binary .bgcode.",
+    )
+
+    # -- Verbosity --
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", default=False,
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_retraction_args(
+    start: float,
+    end: float,
+    step: float,
+    level_height: float = 1.0,
+) -> int:
+    """Validate retraction arguments and return the number of levels.
+
+    Calls :func:`sys.exit` on invalid input.
+    """
+    if start < 0:
+        sys.exit(
+            f"error: --start-retraction must be non-negative (got {start})"
+        )
+    if step <= 0:
+        sys.exit(f"error: --retraction-step must be positive (got {step})")
+    if level_height <= 0:
+        sys.exit(
+            f"error: --level-height must be positive (got {level_height})"
+        )
+    if end <= start:
+        sys.exit(
+            f"error: --end-retraction ({end}) must be greater than "
+            f"--start-retraction ({start})"
+        )
+    spread = end - start
+    remainder = spread % step
+    if remainder > 1e-9 and (step - remainder) > 1e-9:
+        sys.exit(
+            f"error: retraction range {spread} is not evenly divisible "
+            f"by --retraction-step {step}"
+        )
+    num_levels = round(spread / step) + 1
+    if num_levels > MAX_LEVELS:
+        sys.exit(
+            f"error: computed {num_levels} levels exceeds maximum of "
+            f"{MAX_LEVELS} (range {start}→{end}, step {step})"
+        )
+    return num_levels
+
+
+# ---------------------------------------------------------------------------
+# Pipeline helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_common(args: argparse.Namespace) -> dict:
+    """Resolve settings shared across the retraction pipeline."""
+    num_levels = _validate_retraction_args(
+        args.start_retraction, args.end_retraction,
+        args.retraction_step, args.level_height,
+    )
+
+    resolved = gl.resolve_filament_preset(
+        args.filament_type,
+        nozzle_temp=(
+            args.nozzle_temp if args.nozzle_temp is not _UNSET else None
+        ),
+        bed_temp=(
+            args.bed_temp if args.bed_temp is not _UNSET else None
+        ),
+        fan_speed=(
+            args.fan_speed if args.fan_speed is not _UNSET else None
+        ),
+    )
+    nozzle_temp: int = resolved["nozzle_temp"]
+    bed_temp: int = resolved["bed_temp"]
+    fan_speed: int = resolved["fan_speed"]
+
+    nozzle_size: float = args.nozzle_size
+    layer_height: float = (
+        args.layer_height if args.layer_height is not _UNSET
+        else round(nozzle_size * 0.5, 2)
+    )
+    extrusion_width: float = (
+        args.extrusion_width if args.extrusion_width is not _UNSET
+        else round(nozzle_size * 1.125, 2)
+    )
+
+    printer_name: Optional[str] = None
+    bed_shape: Optional[str] = None
+    if args.printer is not None:
+        try:
+            printer_name = gl.resolve_printer(args.printer)
+        except ValueError as exc:
+            sys.exit(f"error: {exc}")
+        if args.bed_center is None:
+            args.bed_center = gl.compute_bed_center(printer_name)
+        bed_shape = gl.compute_bed_shape(printer_name)
+
+    return {
+        "num_levels": num_levels,
+        "nozzle_temp": nozzle_temp,
+        "bed_temp": bed_temp,
+        "fan_speed": fan_speed,
+        "nozzle_size": nozzle_size,
+        "layer_height": layer_height,
+        "extrusion_width": extrusion_width,
+        "printer_name": printer_name,
+        "bed_shape": bed_shape,
+    }
+
+
+def _render_gcode_templates(
+    args: argparse.Namespace,
+    printer_name: Optional[str],
+    nozzle_size: float,
+    nozzle_temp: int,
+    bed_temp: int,
+) -> tuple[Optional[str], Optional[str]]:
+    """Render printer-specific start/end G-code if applicable."""
+    if printer_name is None or args.config_ini is not None:
+        return None, None
+
+    filament_preset = gl.FILAMENT_PRESETS.get(args.filament_type.upper())
+    use_cool_fan = True
+    if filament_preset is not None and filament_preset.get("enclosure"):
+        use_cool_fan = False
+
+    total_z = (
+        BASE_HEIGHT + args.level_height * _validate_retraction_args(
+            args.start_retraction, args.end_retraction,
+            args.retraction_step, args.level_height,
+        )
+    )
+
+    start_gcode = gl.render_start_gcode(
+        printer_name,
+        nozzle_dia=nozzle_size,
+        bed_temp=bed_temp,
+        hotend_temp=nozzle_temp,
+        bed_center=args.bed_center or DEFAULT_BED_CENTER,
+        model_width=BASE_LENGTH,
+        model_depth=BASE_WIDTH,
+        cool_fan=use_cool_fan,
+    )
+    end_gcode = gl.render_end_gcode(
+        printer_name,
+        max_layer_z=total_z,
+    )
+    return start_gcode, end_gcode
+
+
+def _debug_common(
+    args: argparse.Namespace,
+    common: dict,
+    toml_config: Dict[str, object],
+) -> None:
+    """Print common debug information."""
+    cfg_path = _find_config_path(args.config)
+    if cfg_path is not None:
+        print(f"[DEBUG] Config file: {cfg_path}")
+        print(f"[DEBUG] Config values: {toml_config}")
+    else:
+        print("[DEBUG] No config file loaded")
+
+    filament_key = args.filament_type.upper()
+    preset = gl.FILAMENT_PRESETS.get(filament_key)
+    if preset is not None:
+        print(f"[DEBUG] Filament preset '{filament_key}' found")
+    else:
+        print(f"[DEBUG] Filament type '{filament_key}' not in presets, "
+              "using fallback defaults")
+    print(f"[DEBUG] Resolved: nozzle_temp={common['nozzle_temp']} "
+          f"bed_temp={common['bed_temp']} fan_speed={common['fan_speed']}")
+    print(f"[DEBUG] Nozzle: {common['nozzle_size']} mm → "
+          f"layer_height={common['layer_height']} "
+          f"extrusion_width={common['extrusion_width']}")
+    if common["printer_name"] is not None:
+        print(f"[DEBUG] Printer: {common['printer_name']} "
+              f"(bed center: {args.bed_center})")
+
+
+def _upload(args: argparse.Namespace, gcode_path: str) -> None:
+    """Upload G-code if enabled, or print the save path."""
+    if not args.no_upload:
+        if args.verbose:
+            print(f"[DEBUG] Upload target: {args.printer_url}")
+            print(f"[DEBUG] Print after upload: {args.print_after_upload}")
+        print(f"Uploading to {args.printer_url}")
+        filename = gl.prusalink_upload(
+            base_url=args.printer_url,
+            api_key=args.api_key,
+            gcode_path=gcode_path,
+            print_after_upload=args.print_after_upload,
+        )
+        print(f"Uploaded as: {filename}")
+        if args.print_after_upload:
+            print("Print started.")
+    else:
+        print(f"G-code saved to: {gcode_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+
+def _run_pipeline(
+    args: argparse.Namespace,
+    toml_config: Dict[str, object],
+) -> None:
+    """Execute the retraction calibration pipeline."""
+    common = _resolve_common(args)
+    num_levels = common["num_levels"]
+    nozzle_temp = common["nozzle_temp"]
+    bed_temp = common["bed_temp"]
+    fan_speed = common["fan_speed"]
+    nozzle_size = common["nozzle_size"]
+    layer_height = common["layer_height"]
+    extrusion_width = common["extrusion_width"]
+    printer_name = common["printer_name"]
+    bed_shape = common["bed_shape"]
+
+    if args.verbose:
+        _debug_common(args, common, toml_config)
+
+    config = RetractionTowerConfig(
+        num_levels=num_levels,
+        level_height=args.level_height,
+        filament_type=args.filament_type,
+    )
+    out_dir = _resolve_output_dir(args.output_dir, prefix="retraction-")
+
+    if args.verbose:
+        print(
+            f"[DEBUG] Retraction tower: {num_levels} levels, "
+            f"{args.start_retraction}→{args.end_retraction}, "
+            f"step={args.retraction_step}"
+        )
+        print(f"[DEBUG] Output directory: {out_dir}")
+
+    print(
+        f"Filament: {config.filament_type}  "
+        f"Nozzle: {nozzle_size} mm  "
+        f"Retraction: {args.start_retraction}→{args.end_retraction} "
+        f"(step {args.retraction_step})  "
+        f"Temp: {nozzle_temp}°C  Bed: {bed_temp}°C  Fan: {fan_speed}%"
+    )
+
+    # --- Step 1: Generate STL ---
+    suffix = gl.unique_suffix()
+    safe_type = gl.safe_filename_part(config.filament_type)
+    stl_name = (
+        f"retraction_tower_{safe_type}"
+        f"_{args.start_retraction}_{args.retraction_step}x{num_levels}"
+        f"_{suffix}.stl"
+    )
+    stl_path = str(out_dir / stl_name)
+    print(f"Generating model → {stl_path}")
+    generate_retraction_tower_stl(config, stl_path)
+
+    # --- Step 2: Slice ---
+    gcode_ext = gl.gcode_ext(binary=not args.ascii_gcode)
+    raw_gcode_path = str(
+        out_dir / stl_name.replace(".stl", f"_raw{gcode_ext}")
+    )
+    print(f"Slicing → {raw_gcode_path}")
+    if args.verbose:
+        effective_center = args.bed_center or f"{DEFAULT_BED_CENTER} (default)"
+        print(f"[DEBUG] Bed center: {effective_center}")
+
+    start_gcode, end_gcode = _render_gcode_templates(
+        args, printer_name, nozzle_size, nozzle_temp, bed_temp,
+    )
+    if args.verbose and start_gcode is not None:
+        print(f"[DEBUG] Rendered {printer_name} start/end G-code")
+
+    result = slice_retraction_specimen(
+        stl_path=stl_path,
+        output_gcode_path=raw_gcode_path,
+        layer_height=layer_height,
+        extrusion_width=extrusion_width,
+        config_ini=args.config_ini,
+        prusaslicer_path=args.prusaslicer_path,
+        extra_args=args.extra_slicer_args,
+        nozzle_temp=nozzle_temp,
+        bed_temp=bed_temp,
+        fan_speed=fan_speed,
+        bed_center=args.bed_center,
+        bed_shape=bed_shape,
+        nozzle_diameter=nozzle_size,
+        start_gcode=start_gcode,
+        end_gcode=end_gcode,
+        printer_model=printer_name,
+        binary_gcode=not args.ascii_gcode,
+    )
+    if args.verbose:
+        print(f"[DEBUG] PrusaSlicer command: {' '.join(result.cmd)}")
+        if result.stdout.strip():
+            print(f"[DEBUG] PrusaSlicer stdout: {result.stdout.strip()}")
+
+    if not result.ok:
+        print(
+            f"PrusaSlicer failed (exit {result.returncode}):",
+            file=sys.stderr,
+        )
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    # --- Step 3: Insert retraction commands ---
+    final_gcode_path = str(out_dir / stl_name.replace(".stl", gcode_ext))
+    print(f"Inserting retraction commands → {final_gcode_path}")
+    gf = gl.load(raw_gcode_path)
+    gl.inject_thumbnails(
+        gf, stl_path, DEFAULT_THUMBNAILS, verbose=args.verbose,
+    )
+    if printer_name is not None:
+        gl.patch_slicer_metadata(
+            gf, printer_name, nozzle_size, verbose=args.verbose,
+        )
+    levels = compute_retraction_levels(
+        start_length=args.start_retraction,
+        length_step=args.retraction_step,
+        num_levels=num_levels,
+        level_height=args.level_height,
+        base_height=config.base_height,
+    )
+    if args.verbose:
+        print("[DEBUG] Retraction levels:")
+        for lv in levels:
+            print(
+                f"[DEBUG]   Z {lv.z_start:.1f}–{lv.z_end:.1f} mm → "
+                f"{lv.retraction_length:.2f} mm"
+            )
+
+    gf.lines = insert_retraction_commands(gf.lines, levels)
+    gl.save(gf, final_gcode_path)
+
+    # Print retraction level lookup table.
+    print("\nRetraction length by height:")
+    for lv in levels:
+        print(
+            f"  Z {lv.z_start:5.1f} - {lv.z_end:5.1f} mm  "
+            f"->  {lv.retraction_length:.2f} mm"
+        )
+    print(
+        "\nInspect stringing between the towers at each height "
+        "to find your optimal retraction length.\n"
+    )
+
+    # --- Clean up intermediate files ---
+    if not args.keep_files:
+        Path(stl_path).unlink(missing_ok=True)
+        Path(raw_gcode_path).unlink(missing_ok=True)
+
+    # --- Step 4: Upload ---
+    _upload(args, final_gcode_path)
+
+    print("Done.")
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the retraction calibration pipeline."""
+    toml_config = load_config(args.config)
+    _apply_config(
+        args, toml_config,
+        explicit_keys=getattr(args, "_explicit_keys", None),
+    )
+
+    # Fail fast: validate upload requirements.
+    if not args.no_upload and (not args.printer_url or not args.api_key):
+        print(
+            "Error: --printer-url and --api-key are required for upload.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    _run_pipeline(args, toml_config)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Entry point: parse arguments and run the pipeline."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args._explicit_keys = _explicit_keys(parser, argv)
+    run(args)

--- a/src/filament_calibrator/retraction_insert.py
+++ b/src/filament_calibrator/retraction_insert.py
@@ -1,0 +1,145 @@
+"""Retraction length G-code insertion for retraction calibration prints.
+
+Uses ``gcode_lib.iter_layers()`` to identify Z-level boundaries and inserts
+``M207 S{length}`` firmware-retraction commands at the start of each level.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import gcode_lib as gl
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RetractionLevel:
+    """One retraction level's Z range and target retraction length.
+
+    Attributes
+    ----------
+    retraction_length: Firmware retraction length in mm.
+    z_start:           Bottom of level (inclusive), in mm.
+    z_end:             Top of level (exclusive), in mm.
+    """
+    retraction_length: float
+    z_start: float
+    z_end: float
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def retraction_command(length: float) -> str:
+    """Return the G-code command to set firmware retraction length.
+
+    Uses ``M207 S`` (Set Firmware Retraction) which is supported by both
+    Marlin and Klipper (via its G-code compatibility layer).
+    """
+    return f"M207 S{length:.2f} ; retraction calibration level"
+
+
+def compute_retraction_levels(
+    start_length: float,
+    length_step: float,
+    num_levels: int,
+    level_height: float,
+    base_height: float = 0.0,
+) -> List[RetractionLevel]:
+    """Calculate the Z ranges and retraction lengths for each level.
+
+    Level 0 (bottom) gets *start_length*.  Each subsequent level increases
+    by *length_step*.  The base plate (Z 0 → *base_height*) is **not** a
+    retraction level — it prints at the first level's retraction length.
+
+    Parameters
+    ----------
+    start_length: Retraction length for the bottom level in mm.
+    length_step:  Retraction length increase per level in mm.
+    num_levels:   Number of levels.
+    level_height: Height of each level in mm.
+    base_height:  Height of the base plate in mm.
+
+    Returns
+    -------
+    List[RetractionLevel]
+        One entry per level, ordered bottom to top (shortest to longest).
+    """
+    levels: List[RetractionLevel] = []
+    for i in range(num_levels):
+        z_start = base_height + i * level_height
+        z_end = z_start + level_height
+        length = round(start_length + i * length_step, 2)
+        levels.append(
+            RetractionLevel(
+                retraction_length=length,
+                z_start=round(z_start, 4),
+                z_end=round(z_end, 4),
+            ),
+        )
+    return levels
+
+
+def _level_for_z(
+    z: float,
+    levels: List[RetractionLevel],
+) -> RetractionLevel | None:
+    """Return the level that contains height *z*, or ``None``."""
+    for level in levels:
+        if level.z_start <= z < level.z_end:
+            return level
+    return None
+
+
+def insert_retraction_commands(
+    lines: List[gl.GCodeLine],
+    levels: List[RetractionLevel],
+) -> List[gl.GCodeLine]:
+    """Insert ``M207`` retraction-length commands at level boundaries.
+
+    Walks the G-code layer by layer using :func:`gcode_lib.iter_layers`.
+    When a layer's Z height crosses into a new level, an ``M207 S{length}``
+    command is inserted before that layer's lines.
+
+    The base plate layers (below the first level's ``z_start``) receive the
+    first level's retraction length.
+
+    Returns a new list of :class:`gcode_lib.GCodeLine` (following the
+    immutable-input convention from gcode-lib).
+
+    Parameters
+    ----------
+    lines:  Parsed G-code lines.
+    levels: Retraction levels from :func:`compute_retraction_levels`.
+    """
+    if not levels:
+        return list(lines)
+
+    result: List[gl.GCodeLine] = []
+    prev_length: float | None = None
+
+    for z_height, layer_lines in gl.iter_layers(lines):
+        level = _level_for_z(z_height, levels)
+        if level is not None:
+            target_length = level.retraction_length
+        elif z_height < levels[0].z_start:
+            # Base plate — use first level's retraction length
+            target_length = levels[0].retraction_length
+        else:
+            # Above the last level — keep previous retraction length
+            target_length = prev_length
+
+        if target_length is not None and target_length != prev_length:
+            cmd = retraction_command(target_length)
+            result.append(gl.parse_line(cmd))
+            prev_length = target_length
+
+        result.extend(layer_lines)
+
+    return result

--- a/src/filament_calibrator/retraction_model.py
+++ b/src/filament_calibrator/retraction_model.py
@@ -1,0 +1,155 @@
+"""Parametric two-tower model for retraction calibration.
+
+Generates two cylindrical towers on a shared rectangular base plate.
+The towers are spaced apart so that the slicer generates travel moves
+between them, triggering retraction.  When printed with firmware
+retraction enabled and ``M207`` commands inserted at each height level,
+the user can inspect stringing between towers to find the optimal
+retraction distance.
+
+All dimensions are in millimetres.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import cadquery as cq  # type: ignore[import-untyped]
+
+# ---------------------------------------------------------------------------
+# Geometry constants
+# ---------------------------------------------------------------------------
+
+TOWER_DIAMETER: float = 10.0
+"""Diameter of each cylindrical tower in mm."""
+
+TOWER_SPACING: float = 50.0
+"""Centre-to-centre distance between the two towers in mm."""
+
+BASE_LENGTH: float = 70.0
+"""X dimension of the rectangular base plate in mm."""
+
+BASE_WIDTH: float = 20.0
+"""Y dimension of the rectangular base plate in mm."""
+
+BASE_HEIGHT: float = 1.0
+"""Height of the base plate in mm (for bed adhesion)."""
+
+LEVEL_HEIGHT: float = 1.0
+"""Default height per retraction level in mm."""
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RetractionTowerConfig:
+    """Parameters for the retraction calibration two-tower model.
+
+    Attributes
+    ----------
+    num_levels:     Number of retraction-length levels.
+    level_height:   Height per level in mm.
+    tower_diameter: Diameter of each cylindrical tower in mm.
+    tower_spacing:  Centre-to-centre distance between towers in mm.
+    base_length:    X dimension of the base plate in mm.
+    base_width:     Y dimension of the base plate in mm.
+    base_height:    Height of the base plate in mm.
+    filament_type:  Label for filament type (e.g. ``"PLA"``).
+    """
+    num_levels: int
+    level_height: float = LEVEL_HEIGHT
+    tower_diameter: float = TOWER_DIAMETER
+    tower_spacing: float = TOWER_SPACING
+    base_length: float = BASE_LENGTH
+    base_width: float = BASE_WIDTH
+    base_height: float = BASE_HEIGHT
+    filament_type: str = "PLA"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def total_height(config: RetractionTowerConfig) -> float:
+    """Return the total Z height of the model (base + tower levels)."""
+    return config.base_height + config.num_levels * config.level_height
+
+
+# ---------------------------------------------------------------------------
+# Geometry builders
+# ---------------------------------------------------------------------------
+
+
+def _make_base(config: RetractionTowerConfig) -> cq.Workplane:
+    """Create the rectangular base plate centred at the XY origin."""
+    return (
+        cq.Workplane("XY")
+        .box(
+            config.base_length,
+            config.base_width,
+            config.base_height,
+            centered=(True, True, False),
+        )
+    )
+
+
+def _make_tower(
+    config: RetractionTowerConfig,
+    height: float,
+    x_offset: float,
+) -> cq.Workplane:
+    """Create a single cylindrical tower at the given X offset.
+
+    The cylinder is built on the XY plane and translated so that its
+    base sits at ``Z = base_height`` (on top of the base plate).
+    """
+    radius = config.tower_diameter / 2.0
+    return (
+        cq.Workplane("XY")
+        .circle(radius)
+        .extrude(height)
+        .translate((x_offset, 0, config.base_height))
+    )
+
+
+def _make_retraction_towers(config: RetractionTowerConfig) -> cq.Workplane:
+    """Build the complete two-tower model: base plate + two cylinders."""
+    tower_height = config.num_levels * config.level_height
+    half_spacing = config.tower_spacing / 2.0
+
+    base = _make_base(config)
+    left_tower = _make_tower(config, tower_height, -half_spacing)
+    right_tower = _make_tower(config, tower_height, half_spacing)
+
+    return base.union(left_tower).union(right_tower)
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def generate_retraction_tower_stl(
+    config: RetractionTowerConfig,
+    output_path: str,
+) -> str:
+    """One-shot: build the two-tower model and export to STL.
+
+    Parameters
+    ----------
+    config:      Tower configuration.
+    output_path: Where to write the ``.stl`` file.
+
+    Returns
+    -------
+    str
+        The *output_path* (for chaining convenience).
+    """
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    shape = _make_retraction_towers(config)
+    cq.exporters.export(shape, output_path, exportType="STL")
+    return output_path

--- a/src/filament_calibrator/slicer.py
+++ b/src/filament_calibrator/slicer.py
@@ -649,3 +649,129 @@ def slice_em_specimen(
         extra_args=cli_extra,
     )
     return gl.slice_model(exe, req)
+
+
+# Slicer settings for retraction calibration towers (used when no .ini provided).
+RETRACTION_SLICER_ARGS: Dict[str, str] = {
+    "first-layer-height": "0.2",
+    "perimeters": "2",
+    "top-solid-layers": "4",
+    "bottom-solid-layers": "3",
+    "fill-density": "15%",
+    "skirts": "1",
+}
+"""Slicer defaults for retraction calibration towers.
+
+Same structural settings as the temperature tower — 2 perimeters and 15%
+infill provide enough stability for the two cylindrical pillars.
+"""
+
+
+def slice_retraction_specimen(
+    stl_path: str,
+    output_gcode_path: str,
+    layer_height: float = 0.2,
+    extrusion_width: float = 0.45,
+    config_ini: Optional[str] = None,
+    prusaslicer_path: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
+    nozzle_temp: Optional[int] = None,
+    bed_temp: Optional[int] = None,
+    fan_speed: Optional[int] = None,
+    bed_center: Optional[str] = None,
+    bed_shape: Optional[str] = None,
+    nozzle_diameter: Optional[float] = None,
+    start_gcode: Optional[str] = None,
+    end_gcode: Optional[str] = None,
+    printer_model: Optional[str] = None,
+    binary_gcode: bool = True,
+) -> gl.RunResult:
+    """Slice a retraction calibration two-tower STL.
+
+    Always enables ``--use-firmware-retraction`` so that PrusaSlicer emits
+    ``G10``/``G11`` firmware retraction commands instead of explicit
+    ``G1 E-`` moves.  This allows the firmware's retraction length (set
+    by ``M207``) to be varied at each height level.
+
+    When *config_ini* is ``None``, :data:`RETRACTION_SLICER_ARGS` are
+    applied together with the explicit *layer_height* and *extrusion_width*.
+
+    Parameters
+    ----------
+    stl_path:          Path to the input ``.stl`` file.
+    output_gcode_path: Desired output G-code path.
+    layer_height:      Layer height in mm (default 0.2).
+    extrusion_width:   Extrusion width in mm (default 0.45).
+    config_ini:        Optional PrusaSlicer ``.ini`` config file path.
+    prusaslicer_path:  Explicit path to PrusaSlicer executable.
+    extra_args:        Additional raw CLI arguments.
+    nozzle_temp:       Nozzle temperature in °C.
+    bed_temp:          Bed temperature in °C.
+    fan_speed:         Fan speed 0–100 %.
+    bed_center:        Bed centre as ``"X,Y"``.
+    bed_shape:         Bed shape as PrusaSlicer ``--bed-shape`` string.
+    nozzle_diameter:   Nozzle diameter in mm.
+    start_gcode:       Rendered start G-code string.
+    end_gcode:         Rendered end G-code string.
+    printer_model:     Printer model identifier.
+
+    Returns
+    -------
+    gcode_lib.RunResult
+
+    Raises
+    ------
+    FileNotFoundError
+        If PrusaSlicer cannot be found.
+    """
+    exe = gl.find_prusaslicer_executable(explicit_path=prusaslicer_path)
+
+    cli_extra: List[str] = [
+        f"--center={bed_center or DEFAULT_BED_CENTER}",
+        f"--bed-shape={bed_shape or DEFAULT_BED_SHAPE}",
+        f"--thumbnails={DEFAULT_THUMBNAILS}",
+        # Always force firmware retraction so M207 controls retraction
+        # length, even when a user-supplied config.ini is loaded.
+        "--use-firmware-retraction",
+    ]
+    if binary_gcode:
+        cli_extra.append("--binary-gcode")
+
+    if config_ini is None:
+        for key, val in RETRACTION_SLICER_ARGS.items():
+            cli_extra.append(f"--{key}={val}")
+        cli_extra.append(f"--layer-height={layer_height}")
+        cli_extra.append(f"--extrusion-width={extrusion_width}")
+
+    if nozzle_diameter is not None:
+        cli_extra.append(f"--nozzle-diameter={nozzle_diameter}")
+    if nozzle_temp is not None:
+        cli_extra.append(f"--temperature={nozzle_temp}")
+        cli_extra.append(f"--first-layer-temperature={nozzle_temp}")
+    if bed_temp is not None:
+        cli_extra.append(f"--bed-temperature={bed_temp}")
+        cli_extra.append(f"--first-layer-bed-temperature={bed_temp}")
+    if fan_speed is not None:
+        cli_extra.append(f"--max-fan-speed={fan_speed}")
+        cli_extra.append(f"--min-fan-speed={fan_speed}")
+
+    if printer_model is not None:
+        cli_extra.append(f"--printer-model={printer_model}")
+
+    if start_gcode is not None:
+        escaped = start_gcode.replace("\n", "\\n")
+        cli_extra.append(f"--start-gcode={escaped}")
+    if end_gcode is not None:
+        escaped = end_gcode.replace("\n", "\\n")
+        cli_extra.append(f"--end-gcode={escaped}")
+
+    if extra_args:
+        cli_extra.extend(extra_args)
+
+    req = gl.SliceRequest(
+        input_path=stl_path,
+        output_path=output_gcode_path,
+        config_ini=config_ini,
+        extra_args=cli_extra,
+    )
+    return gl.slice_model(exe, req)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -24,6 +24,7 @@ from filament_calibrator.gui import (
     build_em_namespace,
     build_flow_namespace,
     build_pa_namespace,
+    build_retraction_namespace,
     build_temp_tower_namespace,
     find_output_file,
     get_preset,
@@ -1054,3 +1055,71 @@ class TestBuildCalibrationResults:
         )
         assert r.temperature is None
         assert r.extrusion_multiplier == 0.97
+
+
+# ---------------------------------------------------------------------------
+# build_retraction_namespace
+# ---------------------------------------------------------------------------
+
+class TestBuildRetractionNamespace:
+    """Test build_retraction_namespace()."""
+
+    def test_basic(self) -> None:
+        ns = build_retraction_namespace(
+            filament_type="PLA",
+            start_retraction=0.0,
+            end_retraction=2.0,
+            retraction_step=0.1,
+            level_height=1.0,
+            nozzle_temp=215,
+            bed_temp=60,
+            fan_speed=100,
+            nozzle_size=0.4,
+            layer_height=0.2,
+            extrusion_width=0.45,
+            printer="COREONE",
+            ascii_gcode=False,
+            output_dir="/tmp/retraction",
+            config_ini=None,
+            prusaslicer_path=None,
+            printer_url=None,
+            api_key=None,
+            no_upload=True,
+            print_after_upload=False,
+        )
+        assert ns.start_retraction == 0.0
+        assert ns.end_retraction == 2.0
+        assert ns.retraction_step == 0.1
+        assert ns.level_height == 1.0
+        assert ns.nozzle_temp == 215
+        assert ns.layer_height == 0.2
+        assert ns.extrusion_width == 0.45
+        assert ns.verbose is True
+        assert ns.keep_files is True
+
+    def test_empty_strings_become_none(self) -> None:
+        ns = build_retraction_namespace(
+            filament_type="PETG",
+            start_retraction=0.0,
+            end_retraction=2.0,
+            retraction_step=0.1,
+            nozzle_temp=240,
+            bed_temp=80,
+            fan_speed=50,
+            nozzle_size=0.6,
+            layer_height=0.3,
+            extrusion_width=0.68,
+            printer="MK4S",
+            ascii_gcode=True,
+            output_dir="/tmp/retraction",
+            config_ini="",
+            prusaslicer_path="",
+            printer_url="",
+            api_key="",
+            no_upload=True,
+            print_after_upload=False,
+        )
+        assert ns.config_ini is None
+        assert ns.prusaslicer_path is None
+        assert ns.printer_url is None
+        assert ns.api_key is None

--- a/tests/test_retraction_cli.py
+++ b/tests/test_retraction_cli.py
@@ -1,0 +1,873 @@
+"""Tests for filament_calibrator.retraction_cli — retraction CLI orchestration."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import gcode_lib as gl
+
+from filament_calibrator.cli import _KNOWN_TYPES, _UNSET
+from filament_calibrator.retraction_cli import (
+    MAX_LEVELS,
+    _find_config_path,
+    _validate_retraction_args,
+    build_parser,
+    main,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_returns_parser(self):
+        p = build_parser()
+        assert isinstance(p, argparse.ArgumentParser)
+
+    def test_defaults(self):
+        p = build_parser()
+        args = p.parse_args([])
+        assert args.start_retraction == 0.0
+        assert args.end_retraction == 2.0
+        assert args.retraction_step == 0.1
+        assert args.level_height == 1.0
+        assert args.filament_type == "PLA"
+        assert args.nozzle_size == 0.4
+        assert args.layer_height is _UNSET
+        assert args.extrusion_width is _UNSET
+        assert args.bed_temp is _UNSET
+        assert args.fan_speed is _UNSET
+        assert args.nozzle_temp is _UNSET
+        assert args.config_ini is None
+        assert args.prusaslicer_path is None
+        assert args.bed_center is None
+        assert args.extra_slicer_args is None
+        assert args.printer == "COREONE"
+        assert args.printer_url is None
+        assert args.api_key is None
+        assert args.no_upload is False
+        assert args.print_after_upload is False
+        assert args.config is None
+        assert args.output_dir is None
+        assert args.keep_files is False
+        assert args.ascii_gcode is False
+        assert args.verbose is False
+
+    def test_all_options(self):
+        p = build_parser()
+        args = p.parse_args([
+            "--start-retraction", "0.5",
+            "--end-retraction", "3.0",
+            "--retraction-step", "0.5",
+            "--level-height", "2.0",
+            "--filament-type", "PETG",
+            "--nozzle-size", "0.6",
+            "--layer-height", "0.3",
+            "--extrusion-width", "0.68",
+            "--bed-temp", "80",
+            "--fan-speed", "50",
+            "--nozzle-temp", "240",
+            "--config-ini", "/path/to/config.ini",
+            "--prusaslicer-path", "/usr/bin/prusa-slicer",
+            "--bed-center", "90,90",
+            "--printer-url", "http://192.168.1.100",
+            "--api-key", "key123",
+            "--no-upload",
+            "--print-after-upload",
+            "--config", "/path/to/config.toml",
+            "--output-dir", "/tmp/retraction",
+            "--keep-files",
+            "-v",
+        ])
+        assert args.start_retraction == 0.5
+        assert args.end_retraction == 3.0
+        assert args.retraction_step == 0.5
+        assert args.level_height == 2.0
+        assert args.filament_type == "PETG"
+        assert args.nozzle_size == 0.6
+        assert args.layer_height == 0.3
+        assert args.extrusion_width == 0.68
+        assert args.bed_temp == 80
+        assert args.fan_speed == 50
+        assert args.nozzle_temp == 240
+        assert args.verbose is True
+
+    def test_filament_type_help_lists_presets(self):
+        p = build_parser()
+        help_text = p.format_help()
+        assert "PLA" in help_text
+
+
+# ---------------------------------------------------------------------------
+# _validate_retraction_args
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRetractionArgs:
+    def test_valid_range(self):
+        assert _validate_retraction_args(0.0, 2.0, 0.1) == 21
+
+    def test_start_zero_is_valid(self):
+        num = _validate_retraction_args(0.0, 0.5, 0.5)
+        assert num == 2
+
+    def test_start_negative_exits(self):
+        with pytest.raises(SystemExit, match="non-negative"):
+            _validate_retraction_args(-0.1, 2.0, 0.1)
+
+    def test_step_zero_exits(self):
+        with pytest.raises(SystemExit, match="positive"):
+            _validate_retraction_args(0.0, 2.0, 0.0)
+
+    def test_step_negative_exits(self):
+        with pytest.raises(SystemExit, match="positive"):
+            _validate_retraction_args(0.0, 2.0, -0.1)
+
+    def test_level_height_zero_exits(self):
+        with pytest.raises(SystemExit, match="--level-height must be positive"):
+            _validate_retraction_args(0.0, 2.0, 0.1, 0.0)
+
+    def test_level_height_negative_exits(self):
+        with pytest.raises(SystemExit, match="--level-height must be positive"):
+            _validate_retraction_args(0.0, 2.0, 0.1, -1.0)
+
+    def test_end_equal_exits(self):
+        with pytest.raises(SystemExit, match="greater than"):
+            _validate_retraction_args(1.0, 1.0, 0.1)
+
+    def test_end_less_exits(self):
+        with pytest.raises(SystemExit, match="greater than"):
+            _validate_retraction_args(1.0, 0.5, 0.1)
+
+    def test_not_divisible_exits(self):
+        with pytest.raises(SystemExit, match="evenly divisible"):
+            _validate_retraction_args(0.0, 1.0, 0.3)
+
+    def test_too_many_levels_exits(self):
+        with pytest.raises(SystemExit, match="exceeds maximum"):
+            _validate_retraction_args(0.0, 5.1, 0.1)
+
+    def test_max_levels_constant(self):
+        assert MAX_LEVELS == 50
+
+
+# ---------------------------------------------------------------------------
+# _find_config_path
+# ---------------------------------------------------------------------------
+
+
+class TestFindConfigPath:
+    def test_returns_explicit_path(self):
+        assert _find_config_path("/some/path.toml") == "/some/path.toml"
+
+    def test_returns_none_when_no_defaults_exist(self):
+        """When explicit is None and no default config files exist."""
+        with patch(
+            "filament_calibrator.retraction_cli._FIND_CONFIG_PATHS",
+            (Path("/nonexistent/path/a.toml"), Path("/nonexistent/path/b.toml")),
+        ):
+            assert _find_config_path(None) is None
+
+
+# ---------------------------------------------------------------------------
+# run — full pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    @pytest.fixture(autouse=True)
+    def _fix_suffix(self):
+        with patch("gcode_lib.unique_suffix", return_value="abc12"):
+            yield
+
+    def _make_args(self, tmp_path, **overrides):
+        defaults = dict(
+            start_retraction=0.0, end_retraction=0.5,
+            retraction_step=0.5,
+            level_height=1.0, filament_type="PLA",
+            nozzle_size=0.4,
+            layer_height=_UNSET, extrusion_width=_UNSET,
+            bed_temp=_UNSET, fan_speed=_UNSET, nozzle_temp=_UNSET,
+            config_ini=None, prusaslicer_path=None,
+            extra_slicer_args=None, bed_center=None,
+            printer="COREONE",
+            printer_url=None, api_key=None,
+            no_upload=True, print_after_upload=False,
+            output_dir=str(tmp_path), keep_files=False,
+            ascii_gcode=False,
+            config=None, verbose=False,
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_full_pipeline_no_upload(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path)
+        run(args)
+
+        mock_gen.assert_called_once()
+        mock_slice.assert_called_once()
+        mock_levels.assert_called_once()
+        mock_load.assert_called_once()
+        mock_insert.assert_called_once()
+        mock_save.assert_called_once()
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_slicer_failure_exits(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(
+            ok=False, returncode=1, stderr="bad"
+        )
+
+        args = self._make_args(tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            run(args)
+        assert exc_info.value.code == 1
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.prusalink_upload")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_upload(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_upload,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+        mock_upload.return_value = "tower.gcode"
+
+        args = self._make_args(
+            tmp_path,
+            no_upload=False,
+            printer_url="http://192.168.1.100",
+            api_key="key123",
+            print_after_upload=True,
+        )
+        run(args)
+
+        mock_upload.assert_called_once()
+        call_kwargs = mock_upload.call_args[1]
+        assert call_kwargs["base_url"] == "http://192.168.1.100"
+        assert call_kwargs["api_key"] == "key123"
+        assert call_kwargs["print_after_upload"] is True
+
+    @patch("filament_calibrator.retraction_cli.load_config", return_value={})
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_upload_missing_url_exits(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        mock_load_config, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            no_upload=False,
+            printer_url=None,
+            api_key=None,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            run(args)
+        assert exc_info.value.code == 1
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_keep_files(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        stl = tmp_path / "retraction_tower_PLA_0.0_0.5x2_abc12.stl"
+        raw_gcode = tmp_path / "retraction_tower_PLA_0.0_0.5x2_abc12_raw.bgcode"
+        stl.write_text("dummy")
+        raw_gcode.write_text("dummy")
+
+        mock_gen.return_value = str(stl)
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, keep_files=True)
+        run(args)
+
+        assert stl.exists()
+        assert raw_gcode.exists()
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_no_keep_files_cleans_up(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        stl = tmp_path / "retraction_tower_PLA_0.0_0.5x2_abc12.stl"
+        raw_gcode = tmp_path / "retraction_tower_PLA_0.0_0.5x2_abc12_raw.bgcode"
+        stl.write_text("dummy")
+        raw_gcode.write_text("dummy")
+
+        mock_gen.return_value = str(stl)
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, keep_files=False)
+        run(args)
+
+        assert not stl.exists()
+        assert not raw_gcode.exists()
+
+    @patch("filament_calibrator.retraction_cli.load_config", return_value={})
+    @patch("filament_calibrator.retraction_cli._find_config_path",
+           return_value=None)
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_verbose_output(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        mock_find_config, mock_load_config, tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(
+            ok=True, cmd=["prusa-slicer", "--slice"], stdout="", stderr=""
+        )
+        mock_levels.return_value = [
+            MagicMock(
+                z_start=1.0, z_end=2.0, retraction_length=0.0,
+            ),
+        ]
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, verbose=True)
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "[DEBUG]" in captured.out
+        assert "No config file loaded" in captured.out
+        assert "Filament preset 'PLA' found" in captured.out
+        assert "Bed center:" in captured.out
+        assert "PrusaSlicer command:" in captured.out
+        assert "Retraction levels:" in captured.out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_no_verbose_no_debug(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, verbose=False)
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "[DEBUG]" not in captured.out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_verbose_shows_slicer_stdout(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(
+            ok=True, cmd=["prusa-slicer"],
+            stdout="Slicing complete in 2.1s", stderr=""
+        )
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, verbose=True)
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "PrusaSlicer stdout: Slicing complete in 2.1s" in captured.out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_verbose_unknown_filament(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(
+            ok=True, cmd=["prusa-slicer"], stdout="", stderr=""
+        )
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(
+            tmp_path, verbose=True, filament_type="EXOTIC",
+        )
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "not in presets" in captured.out
+        assert "fallback defaults" in captured.out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_verbose_shows_config_file(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path, capsys
+    ):
+        cfg = tmp_path / "test.toml"
+        cfg.write_text('filament-type = "PLA"\n')
+
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(
+            ok=True, cmd=["prusa-slicer"], stdout="", stderr=""
+        )
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, verbose=True, config=str(cfg))
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "Config file:" in captured.out
+        assert str(cfg) in captured.out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.prusalink_upload")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_verbose_upload(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_upload,
+        mock_inject, mock_patch_meta, tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(
+            ok=True, cmd=["prusa-slicer"], stdout="", stderr=""
+        )
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+        mock_upload.return_value = "tower.gcode"
+
+        args = self._make_args(
+            tmp_path, verbose=True,
+            no_upload=False,
+            printer_url="http://192.168.1.100",
+            api_key="key123",
+            print_after_upload=True,
+        )
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "Upload target: http://192.168.1.100" in captured.out
+        assert "Print after upload: True" in captured.out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_slicer_receives_correct_args(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(
+            tmp_path,
+            layer_height=0.3,
+            extrusion_width=0.6,
+            bed_center="90,90",
+        )
+        run(args)
+
+        slice_kwargs = mock_slice.call_args[1]
+        assert slice_kwargs["layer_height"] == 0.3
+        assert slice_kwargs["extrusion_width"] == 0.6
+        assert slice_kwargs["bed_center"] == "90,90"
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_preset_temps_passed_to_slicer(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """Filament preset nozzle/bed/fan are forwarded to slicer."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        pla = gl.FILAMENT_PRESETS["PLA"]
+        args = self._make_args(tmp_path, filament_type="PLA")
+        run(args)
+
+        slice_kwargs = mock_slice.call_args[1]
+        assert slice_kwargs["nozzle_temp"] == int(pla["hotend"])
+        assert slice_kwargs["bed_temp"] == int(pla["bed"])
+        assert slice_kwargs["fan_speed"] == int(pla["fan"])
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_explicit_temps_override_preset(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """Explicit --nozzle-temp/--bed-temp/--fan-speed override preset."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(
+            tmp_path,
+            filament_type="PLA",
+            nozzle_temp=280,
+            bed_temp=90,
+            fan_speed=50,
+        )
+        run(args)
+
+        slice_kwargs = mock_slice.call_args[1]
+        assert slice_kwargs["nozzle_temp"] == 280
+        assert slice_kwargs["bed_temp"] == 90
+        assert slice_kwargs["fan_speed"] == 50
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_nozzle_size_derivation(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """Nozzle size derives layer_height and extrusion_width."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, nozzle_size=0.6)
+        run(args)
+
+        slice_kwargs = mock_slice.call_args[1]
+        assert slice_kwargs["layer_height"] == pytest.approx(0.3)
+        assert slice_kwargs["extrusion_width"] == pytest.approx(
+            round(0.6 * 1.125, 2),
+        )
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_ascii_gcode(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """--ascii-gcode passes binary_gcode=False to slicer."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, ascii_gcode=True)
+        run(args)
+
+        slice_kwargs = mock_slice.call_args[1]
+        assert slice_kwargs["binary_gcode"] is False
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_config_file_applies_defaults(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        cfg = tmp_path / "test.toml"
+        cfg.write_text('filament-type = "PETG"\n')
+
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, config=str(cfg))
+        run(args)
+
+        gen_call = mock_gen.call_args
+        tower_config = gen_call[0][0]
+        assert tower_config.filament_type == "PETG"
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_no_printer_skips_metadata(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """When --printer is None, patch_slicer_metadata is not called."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, printer=None)
+        run(args)
+
+        mock_patch_meta.assert_not_called()
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_invalid_printer_exits(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """Unknown printer name causes sys.exit via resolve_printer ValueError."""
+        with patch(
+            "filament_calibrator.retraction_cli.gl.resolve_printer",
+            side_effect=ValueError("Unknown printer 'BADPRINTER'"),
+        ):
+            args = self._make_args(tmp_path, printer="BADPRINTER")
+            with pytest.raises(SystemExit, match="Unknown printer"):
+                run(args)
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_enclosure_filament_disables_cool_fan(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path
+    ):
+        """ABS (enclosure filament) sets use_cool_fan=False in start G-code."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = []
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path, filament_type="ABS")
+        with patch(
+            "filament_calibrator.retraction_cli.gl.render_start_gcode",
+            return_value="start",
+        ) as mock_start, patch(
+            "filament_calibrator.retraction_cli.gl.render_end_gcode",
+            return_value="end",
+        ):
+            run(args)
+            mock_start.assert_called_once()
+            assert mock_start.call_args[1]["cool_fan"] is False
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("filament_calibrator.retraction_cli.gl.save")
+    @patch("filament_calibrator.retraction_cli.gl.load")
+    @patch("filament_calibrator.retraction_cli.insert_retraction_commands")
+    @patch("filament_calibrator.retraction_cli.compute_retraction_levels")
+    @patch("filament_calibrator.retraction_cli.slice_retraction_specimen")
+    @patch("filament_calibrator.retraction_cli.generate_retraction_tower_stl")
+    def test_prints_retraction_table(
+        self, mock_gen, mock_slice, mock_levels,
+        mock_insert, mock_load, mock_save, mock_inject, mock_patch_meta,
+        tmp_path, capsys
+    ):
+        """Pipeline prints a retraction length lookup table."""
+        mock_gen.return_value = str(tmp_path / "tower.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_levels.return_value = [
+            MagicMock(z_start=1.0, z_end=2.0, retraction_length=0.0),
+            MagicMock(z_start=2.0, z_end=3.0, retraction_length=0.5),
+        ]
+        mock_load.return_value = MagicMock(lines=[])
+        mock_insert.return_value = []
+
+        args = self._make_args(tmp_path)
+        run(args)
+
+        captured = capsys.readouterr()
+        assert "Retraction length by height:" in captured.out
+        assert "0.00 mm" in captured.out
+        assert "0.50 mm" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    @patch("filament_calibrator.retraction_cli.run")
+    def test_main_parses_and_runs(self, mock_run):
+        main(["--no-upload"])
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args.no_upload is True
+        assert args.start_retraction == 0.0
+        assert args.end_retraction == 2.0

--- a/tests/test_retraction_insert.py
+++ b/tests/test_retraction_insert.py
@@ -1,0 +1,278 @@
+"""Tests for filament_calibrator.retraction_insert — retraction G-code insertion."""
+from __future__ import annotations
+
+import pytest
+
+import gcode_lib as gl
+
+from filament_calibrator.retraction_insert import (
+    RetractionLevel,
+    _level_for_z,
+    compute_retraction_levels,
+    insert_retraction_commands,
+    retraction_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _lines(text: str):
+    return gl.parse_lines(text)
+
+
+def _raw_texts(lines):
+    return [line.raw for line in lines]
+
+
+# ---------------------------------------------------------------------------
+# RetractionLevel
+# ---------------------------------------------------------------------------
+
+
+class TestRetractionLevel:
+    def test_attributes(self):
+        lv = RetractionLevel(retraction_length=0.5, z_start=1.0, z_end=2.0)
+        assert lv.retraction_length == 0.5
+        assert lv.z_start == 1.0
+        assert lv.z_end == 2.0
+
+
+# ---------------------------------------------------------------------------
+# retraction_command
+# ---------------------------------------------------------------------------
+
+
+class TestRetractionCommand:
+    def test_m207_format(self):
+        result = retraction_command(0.5)
+        assert result == "M207 S0.50 ; retraction calibration level"
+
+    def test_two_decimal_places(self):
+        result = retraction_command(1.0)
+        assert "S1.00" in result
+
+    def test_zero_value(self):
+        result = retraction_command(0.0)
+        assert "S0.00" in result
+
+    def test_small_value(self):
+        result = retraction_command(0.1)
+        assert "S0.10" in result
+
+
+# ---------------------------------------------------------------------------
+# compute_retraction_levels
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRetractionLevels:
+    def test_basic_levels(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0)
+        assert len(levels) == 3
+        assert levels[0].retraction_length == pytest.approx(0.0)
+        assert levels[0].z_start == pytest.approx(0.0)
+        assert levels[0].z_end == pytest.approx(1.0)
+        assert levels[1].retraction_length == pytest.approx(0.1)
+        assert levels[2].retraction_length == pytest.approx(0.2)
+        assert levels[2].z_start == pytest.approx(2.0)
+        assert levels[2].z_end == pytest.approx(3.0)
+
+    def test_with_base_height(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0, base_height=1.0)
+        assert levels[0].z_start == pytest.approx(1.0)
+        assert levels[0].z_end == pytest.approx(2.0)
+        assert levels[1].z_start == pytest.approx(2.0)
+        assert levels[2].z_end == pytest.approx(4.0)
+
+    def test_single_level(self):
+        levels = compute_retraction_levels(0.5, 0.1, 1, 2.0)
+        assert len(levels) == 1
+        assert levels[0].retraction_length == pytest.approx(0.5)
+        assert levels[0].z_start == pytest.approx(0.0)
+        assert levels[0].z_end == pytest.approx(2.0)
+
+    def test_zero_levels(self):
+        levels = compute_retraction_levels(0.0, 0.1, 0, 1.0)
+        assert levels == []
+
+    def test_custom_level_height(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 2.0)
+        assert levels[0].z_end == pytest.approx(2.0)
+        assert levels[1].z_start == pytest.approx(2.0)
+        assert levels[2].z_start == pytest.approx(4.0)
+
+    def test_rounding_prevents_drift(self):
+        """Retraction lengths are rounded to prevent float drift."""
+        levels = compute_retraction_levels(0.0, 0.1, 10, 1.0)
+        # Without rounding, 0.1 * 3 = 0.30000000000000004
+        assert levels[3].retraction_length == pytest.approx(0.3)
+        assert levels[9].retraction_length == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# _level_for_z
+# ---------------------------------------------------------------------------
+
+
+class TestLevelForZ:
+    def test_in_first_level(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0, base_height=1.0)
+        assert _level_for_z(1.5, levels).retraction_length == pytest.approx(0.0)
+
+    def test_in_second_level(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0, base_height=1.0)
+        assert _level_for_z(2.5, levels).retraction_length == pytest.approx(0.1)
+
+    def test_at_boundary(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0, base_height=1.0)
+        # z_start is inclusive
+        assert _level_for_z(2.0, levels).retraction_length == pytest.approx(0.1)
+
+    def test_below_range(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0, base_height=1.0)
+        assert _level_for_z(0.5, levels) is None
+
+    def test_above_range(self):
+        levels = compute_retraction_levels(0.0, 0.1, 3, 1.0, base_height=1.0)
+        assert _level_for_z(4.5, levels) is None
+
+    def test_empty_levels(self):
+        assert _level_for_z(0.5, []) is None
+
+
+# ---------------------------------------------------------------------------
+# insert_retraction_commands
+# ---------------------------------------------------------------------------
+
+
+class TestInsertRetractionCommands:
+    def test_basic_insertion(self):
+        """M207 commands are inserted at level boundaries."""
+        gcode = (
+            "G28\n"
+            "G1 Z1.2 F1000\n"
+            "G1 X10 E1\n"
+            "G1 Z2.2 F1000\n"
+            "G1 X20 E2\n"
+        )
+        lines = _lines(gcode)
+        levels = compute_retraction_levels(0.0, 0.5, 2, 1.0, base_height=1.0)
+        result = insert_retraction_commands(lines, levels)
+        texts = _raw_texts(result)
+
+        m207_lines = [t for t in texts if t.startswith("M207")]
+        assert len(m207_lines) == 2
+        assert "S0.00" in m207_lines[0]
+        assert "S0.50" in m207_lines[1]
+
+    def test_base_plate_gets_first_level_retraction(self):
+        """Layers below the first level's z_start get first level's retraction."""
+        gcode = (
+            "G1 Z0.2 F1000\n"
+            "G1 X10 E1\n"
+            "G1 Z0.4 F1000\n"
+            "G1 X20 E2\n"
+        )
+        lines = _lines(gcode)
+        levels = compute_retraction_levels(0.5, 0.1, 2, 1.0, base_height=1.0)
+        result = insert_retraction_commands(lines, levels)
+        texts = _raw_texts(result)
+
+        m207_lines = [t for t in texts if t.startswith("M207")]
+        assert len(m207_lines) == 1
+        assert "S0.50" in m207_lines[0]
+
+    def test_no_duplicate_commands(self):
+        """Same-level layers don't get duplicate M207 commands."""
+        gcode = (
+            "G1 Z1.2 F1000\n"
+            "G1 X10 E1\n"
+            "G1 Z1.4 F1000\n"
+            "G1 X20 E2\n"
+            "G1 Z1.6 F1000\n"
+            "G1 X30 E3\n"
+        )
+        lines = _lines(gcode)
+        levels = compute_retraction_levels(0.0, 0.5, 1, 1.0, base_height=1.0)
+        result = insert_retraction_commands(lines, levels)
+        texts = _raw_texts(result)
+
+        m207_lines = [t for t in texts if t.startswith("M207")]
+        assert len(m207_lines) == 1
+
+    def test_empty_levels_no_modification(self):
+        gcode = "G28\nG1 X10 E1\n"
+        lines = _lines(gcode)
+        result = insert_retraction_commands(lines, [])
+        assert len(result) == len(lines)
+
+    def test_empty_lines(self):
+        result = insert_retraction_commands(
+            [], compute_retraction_levels(0.0, 0.1, 3, 1.0),
+        )
+        assert result == []
+
+    def test_above_last_level_keeps_retraction(self):
+        """Layers above the last level don't generate new M207 commands."""
+        gcode = (
+            "G1 Z1.2 F1000\n"
+            "G1 X10 E1\n"
+            "G1 Z100.0 F1000\n"
+            "G1 X30 E3\n"
+        )
+        lines = _lines(gcode)
+        levels = compute_retraction_levels(0.5, 0.1, 1, 1.0, base_height=1.0)
+        result = insert_retraction_commands(lines, levels)
+        texts = _raw_texts(result)
+
+        m207_lines = [t for t in texts if t.startswith("M207")]
+        assert len(m207_lines) == 1
+        assert "S0.50" in m207_lines[0]
+
+    def test_command_order_in_output(self):
+        """M207 command appears before the first line of the new-level layer."""
+        gcode = (
+            "G1 Z1.2 F1000\n"
+            "G1 X10 E1\n"
+            "G1 Z2.2 F1000\n"
+            "G1 X20 E2\n"
+        )
+        lines = _lines(gcode)
+        levels = compute_retraction_levels(0.0, 0.5, 2, 1.0, base_height=1.0)
+        result = insert_retraction_commands(lines, levels)
+        texts = _raw_texts(result)
+
+        idx_m207_0 = next(
+            (i for i, t in enumerate(texts) if "S0.00" in t), -1,
+        )
+        idx_z1_2 = next(
+            (i for i, t in enumerate(texts) if "Z1.2" in t), -1,
+        )
+        assert idx_m207_0 != -1
+        assert idx_z1_2 != -1
+        assert idx_m207_0 < idx_z1_2
+
+        idx_m207_1 = next(
+            (i for i, t in enumerate(texts) if "S0.50" in t), -1,
+        )
+        idx_z2_2 = next(
+            (i for i, t in enumerate(texts) if "Z2.2" in t), -1,
+        )
+        assert idx_m207_1 != -1
+        assert idx_z2_2 != -1
+        assert idx_m207_1 < idx_z2_2
+
+    def test_immutable_input(self):
+        """Original list is not mutated."""
+        gcode = (
+            "G1 Z1.2 F1000\n"
+            "G1 X10 E1\n"
+        )
+        lines = _lines(gcode)
+        original_len = len(lines)
+        levels = compute_retraction_levels(0.0, 0.5, 1, 1.0, base_height=1.0)
+        insert_retraction_commands(lines, levels)
+        assert len(lines) == original_len

--- a/tests/test_retraction_model.py
+++ b/tests/test_retraction_model.py
@@ -1,0 +1,268 @@
+"""Tests for filament_calibrator.retraction_model — two-tower retraction geometry."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from filament_calibrator.retraction_model import (
+    BASE_HEIGHT,
+    BASE_LENGTH,
+    BASE_WIDTH,
+    LEVEL_HEIGHT,
+    TOWER_DIAMETER,
+    TOWER_SPACING,
+    RetractionTowerConfig,
+    _make_base,
+    _make_retraction_towers,
+    _make_tower,
+    generate_retraction_tower_stl,
+    total_height,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_tower_diameter(self):
+        assert TOWER_DIAMETER == 10.0
+
+    def test_tower_spacing(self):
+        assert TOWER_SPACING == 50.0
+
+    def test_base_length(self):
+        assert BASE_LENGTH == 70.0
+
+    def test_base_width(self):
+        assert BASE_WIDTH == 20.0
+
+    def test_base_height(self):
+        assert BASE_HEIGHT == 1.0
+
+    def test_level_height(self):
+        assert LEVEL_HEIGHT == 1.0
+
+
+# ---------------------------------------------------------------------------
+# RetractionTowerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestRetractionTowerConfig:
+    def test_defaults(self):
+        config = RetractionTowerConfig(num_levels=10)
+        assert config.num_levels == 10
+        assert config.level_height == LEVEL_HEIGHT
+        assert config.tower_diameter == TOWER_DIAMETER
+        assert config.tower_spacing == TOWER_SPACING
+        assert config.base_length == BASE_LENGTH
+        assert config.base_width == BASE_WIDTH
+        assert config.base_height == BASE_HEIGHT
+        assert config.filament_type == "PLA"
+
+    def test_custom_values(self):
+        config = RetractionTowerConfig(
+            num_levels=20,
+            level_height=2.0,
+            tower_diameter=15.0,
+            tower_spacing=60.0,
+            base_length=80.0,
+            base_width=25.0,
+            base_height=2.0,
+            filament_type="PETG",
+        )
+        assert config.num_levels == 20
+        assert config.level_height == 2.0
+        assert config.tower_diameter == 15.0
+        assert config.tower_spacing == 60.0
+        assert config.base_length == 80.0
+        assert config.base_width == 25.0
+        assert config.base_height == 2.0
+        assert config.filament_type == "PETG"
+
+
+# ---------------------------------------------------------------------------
+# total_height
+# ---------------------------------------------------------------------------
+
+
+class TestTotalHeight:
+    def test_default_config(self):
+        config = RetractionTowerConfig(num_levels=10)
+        assert total_height(config) == pytest.approx(11.0)
+
+    def test_custom_level_height(self):
+        config = RetractionTowerConfig(num_levels=5, level_height=2.0)
+        assert total_height(config) == pytest.approx(11.0)
+
+    def test_custom_base_height(self):
+        config = RetractionTowerConfig(
+            num_levels=10, level_height=1.0, base_height=2.0,
+        )
+        assert total_height(config) == pytest.approx(12.0)
+
+    def test_single_level(self):
+        config = RetractionTowerConfig(num_levels=1)
+        assert total_height(config) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# _make_base (mocked CadQuery)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeBase:
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_creates_box(self, mock_cq):
+        """Base plate is created as a box with correct dimensions."""
+        config = RetractionTowerConfig(num_levels=5)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+
+        _make_base(config)
+
+        mock_cq.Workplane.assert_called_with("XY")
+        mock_wp.box.assert_called_once_with(
+            config.base_length,
+            config.base_width,
+            config.base_height,
+            centered=(True, True, False),
+        )
+
+
+# ---------------------------------------------------------------------------
+# _make_tower (mocked CadQuery)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeTower:
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_creates_cylinder(self, mock_cq):
+        """Tower is created as a circle extruded to height."""
+        config = RetractionTowerConfig(num_levels=5)
+        height = 5.0
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.circle.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+
+        _make_tower(config, height, 25.0)
+
+        mock_wp.circle.assert_called_once_with(config.tower_diameter / 2.0)
+        mock_wp.extrude.assert_called_once_with(height)
+        mock_wp.translate.assert_called_once_with(
+            (25.0, 0, config.base_height),
+        )
+
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_negative_offset(self, mock_cq):
+        """Tower can be created at negative X offset."""
+        config = RetractionTowerConfig(num_levels=5)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.circle.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+
+        _make_tower(config, 5.0, -25.0)
+
+        mock_wp.translate.assert_called_once_with(
+            (-25.0, 0, config.base_height),
+        )
+
+
+# ---------------------------------------------------------------------------
+# _make_retraction_towers (mocked CadQuery)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeRetractionTowers:
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_creates_base_and_two_towers(self, mock_cq):
+        """Model consists of a base plate and two cylindrical towers."""
+        config = RetractionTowerConfig(num_levels=5)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.circle.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+
+        _make_retraction_towers(config)
+
+        # base + 2 towers = 3 Workplane("XY") calls
+        assert mock_cq.Workplane.call_count == 3
+        # Two union calls (left tower + right tower)
+        assert mock_wp.union.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# generate_retraction_tower_stl
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateRetractionTowerStl:
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_creates_output_dir(self, mock_cq, tmp_path):
+        """Parent directory is created if it doesn't exist."""
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.circle.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+
+        output = tmp_path / "nested" / "dir" / "tower.stl"
+        config = RetractionTowerConfig(num_levels=5)
+        result = generate_retraction_tower_stl(config, str(output))
+
+        assert result == str(output)
+        assert output.parent.exists()
+        mock_cq.exporters.export.assert_called_once()
+
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_returns_output_path(self, mock_cq, tmp_path):
+        """Function returns the output path for chaining."""
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.circle.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+
+        output = str(tmp_path / "test.stl")
+        config = RetractionTowerConfig(num_levels=3)
+        result = generate_retraction_tower_stl(config, output)
+
+        assert result == output
+
+    @patch("filament_calibrator.retraction_model.cq")
+    def test_exports_as_stl(self, mock_cq, tmp_path):
+        """Exports in STL format."""
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.circle.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+
+        output = str(tmp_path / "test.stl")
+        config = RetractionTowerConfig(num_levels=3)
+        generate_retraction_tower_stl(config, output)
+
+        export_call = mock_cq.exporters.export.call_args
+        assert export_call[1]["exportType"] == "STL"
+        assert export_call[0][1] == output

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -14,11 +14,13 @@ from filament_calibrator.slicer import (
     EM_SLICER_ARGS,
     PA_PATTERN_SLICER_ARGS,
     PA_SLICER_ARGS,
+    RETRACTION_SLICER_ARGS,
     VASE_MODE_SLICER_ARGS,
     slice_em_specimen,
     slice_flow_specimen,
     slice_pa_pattern,
     slice_pa_specimen,
+    slice_retraction_specimen,
     slice_tower,
 )
 
@@ -1842,6 +1844,258 @@ class TestSliceEmSpecimen:
 
         slice_em_specimen(
             "/tmp/cube.stl", "/tmp/cube.gcode",
+            config_ini="/config.ini",
+            extra_args=["--custom", "val"],
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--custom" in req.extra_args
+        assert "val" in req.extra_args
+
+
+# ---------------------------------------------------------------------------
+# RETRACTION_SLICER_ARGS
+# ---------------------------------------------------------------------------
+
+
+class TestRetractionSlicerArgs:
+    def test_has_required_keys(self):
+        assert "first-layer-height" in RETRACTION_SLICER_ARGS
+        assert "perimeters" in RETRACTION_SLICER_ARGS
+        assert "fill-density" in RETRACTION_SLICER_ARGS
+
+    def test_two_perimeters(self):
+        assert RETRACTION_SLICER_ARGS["perimeters"] == "2"
+
+    def test_no_layer_height_key(self):
+        # layer-height is passed explicitly by slice_retraction_specimen
+        assert "layer-height" not in RETRACTION_SLICER_ARGS
+
+
+# ---------------------------------------------------------------------------
+# slice_retraction_specimen
+# ---------------------------------------------------------------------------
+
+
+class TestSliceRetractionSpecimen:
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_with_config_ini(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="ok", stderr=""
+        )
+
+        result = slice_retraction_specimen(
+            stl_path="/tmp/tower.stl",
+            output_gcode_path="/tmp/tower.gcode",
+            config_ini="/path/to/config.ini",
+        )
+
+        assert result.ok
+        req = mock_slice.call_args[0][1]
+        assert req.config_ini == "/path/to/config.ini"
+        # With config_ini, default slicer args should NOT be added
+        for key in RETRACTION_SLICER_ARGS:
+            assert f"--{key}" not in " ".join(req.extra_args)
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_without_config_ini(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="ok", stderr=""
+        )
+
+        slice_retraction_specimen(
+            stl_path="/tmp/tower.stl",
+            output_gcode_path="/tmp/tower.gcode",
+        )
+
+        req = mock_slice.call_args[0][1]
+        # Default args should be applied
+        for key, val in RETRACTION_SLICER_ARGS.items():
+            assert f"--{key}={val}" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_firmware_retraction_always_enabled(self, mock_find, mock_slice):
+        """--use-firmware-retraction is always added, even with config_ini."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        # Without config_ini
+        slice_retraction_specimen("/tmp/t.stl", "/tmp/t.gcode")
+        req = mock_slice.call_args[0][1]
+        assert "--use-firmware-retraction" in req.extra_args
+
+        # With config_ini
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode", config_ini="/c.ini",
+        )
+        req = mock_slice.call_args[0][1]
+        assert "--use-firmware-retraction" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_layer_height_and_extrusion_width(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode",
+            layer_height=0.3, extrusion_width=0.68,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--layer-height=0.3" in req.extra_args
+        assert "--extrusion-width=0.68" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_temp_bed_fan(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode",
+            nozzle_temp=230, bed_temp=80, fan_speed=50,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--temperature=230" in req.extra_args
+        assert "--first-layer-temperature=230" in req.extra_args
+        assert "--bed-temperature=80" in req.extra_args
+        assert "--first-layer-bed-temperature=80" in req.extra_args
+        assert "--max-fan-speed=50" in req.extra_args
+        assert "--min-fan-speed=50" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_bed_center_default(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen("/tmp/t.stl", "/tmp/t.gcode")
+
+        req = mock_slice.call_args[0][1]
+        assert f"--center={DEFAULT_BED_CENTER}" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_bed_center_custom(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode", bed_center="90,90",
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--center=90,90" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_nozzle_diameter(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode", nozzle_diameter=0.6,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--nozzle-diameter=0.6" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_binary_gcode_default(self, mock_find, mock_slice):
+        """binary_gcode defaults to True."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen("/tmp/t.stl", "/tmp/t.gcode")
+
+        req = mock_slice.call_args[0][1]
+        assert "--binary-gcode" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_binary_gcode_false(self, mock_find, mock_slice):
+        """binary_gcode=False → no --binary-gcode."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode", binary_gcode=False,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--binary-gcode" not in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_printer_model_passed(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode", printer_model="COREONE",
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--printer-model=COREONE" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_start_end_gcode(self, mock_find, mock_slice):
+        """start_gcode and end_gcode are escaped and passed."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode",
+            start_gcode="G28\nG1 Z5",
+            end_gcode="M84\n",
+        )
+
+        req = mock_slice.call_args[0][1]
+        start_args = [a for a in req.extra_args if a.startswith("--start-gcode")]
+        end_args = [a for a in req.extra_args if a.startswith("--end-gcode")]
+        assert len(start_args) == 1
+        assert len(end_args) == 1
+        assert "\\n" in start_args[0]
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_extra_args_appended_retraction(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_retraction_specimen(
+            "/tmp/t.stl", "/tmp/t.gcode",
             config_ini="/config.ini",
             extra_args=["--custom", "val"],
         )


### PR DESCRIPTION
## Summary
- Adds `retraction-test` CLI — the 5th calibration tool in the suite
- Generates two cylindrical towers spaced apart; PrusaSlicer travel moves between them trigger retraction
- At each height level, firmware retraction length is changed via `M207 S<length>` so users can inspect stringing to find optimal retraction distance
- Inputs: start length (default 0mm), end length (default 2mm), step (default 0.1mm)

### New files
- `retraction_model.py` — Two-cylinder CadQuery geometry on shared rectangular base
- `retraction_insert.py` — G-code M207 command insertion at Z boundaries
- `retraction_cli.py` — Full CLI pipeline with validation, slicing, upload support
- Tests for all three new modules

### Modified files
- `slicer.py` — Added `RETRACTION_SLICER_ARGS` and `slice_retraction_specimen()` (always forces `--use-firmware-retraction`)
- `gui.py` — Added `build_retraction_namespace()` helper
- `pyproject.toml` — Added `retraction-test` entry point
- `CLAUDE.md` — Documented 5th tool, pipeline, slicer args, entry point
- `test_slicer.py`, `test_gui.py` — Added retraction test coverage

## Test plan
- [x] 777 tests passing
- [x] 100% statement coverage across all 21 modules
- [ ] Generate sample STL and verify geometry in PrusaSlicer
- [ ] Slice and verify `--use-firmware-retraction` produces G10/G11
- [ ] Verify M207 commands inserted at correct Z heights

🤖 Generated with [Claude Code](https://claude.com/claude-code)