### PR TITLE
Auto-update temp tower start/end temps from filament preset

### DIFF
--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -615,6 +615,9 @@ def apply_ini_to_session(
         state["em_nozzle_temp"] = nt
         state["flow_nozzle_temp"] = nt
         state["pa_nozzle_temp"] = nt
+        # Derive a temp tower range centred on the INI temperature.
+        state["tt_start_temp"] = nt + 15
+        state["tt_end_temp"] = nt - 15
 
     if "bed_temp" in ini_vals:
         bt = ini_vals["bed_temp"]
@@ -932,6 +935,8 @@ def _app() -> None:  # pragma: no cover
         st.session_state["_preset_nozzle_size"] = nozzle_size
 
     _widget_defaults = {
+        "tt_start_temp": preset["temp_max"],
+        "tt_end_temp": preset["temp_min"],
         "tt_bed_temp": preset["bed"],
         "tt_fan": preset["fan"],
         "em_nozzle_temp": preset["hotend"],
@@ -978,18 +983,18 @@ def _app() -> None:  # pragma: no cover
         with col1:
             start_temp = st.number_input(
                 "Start Temp (\u00b0C) \u2014 bottom",
-                value=preset["temp_max"],
                 min_value=150,
                 max_value=350,
                 step=5,
+                key="tt_start_temp",
             )
         with col2:
             end_temp = st.number_input(
                 "End Temp (\u00b0C) \u2014 top",
-                value=preset["temp_min"],
                 min_value=150,
                 max_value=350,
                 step=5,
+                key="tt_end_temp",
             )
         with col3:
             temp_step = st.number_input(

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -766,10 +766,12 @@ class TestApplyIniToSession:
         }
         apply_ini_to_session(state, ini_vals)
 
-        # Nozzle temp → EM + flow + PA tabs.
+        # Nozzle temp → EM + flow + PA tabs, temp tower range.
         assert state["em_nozzle_temp"] == 220
         assert state["flow_nozzle_temp"] == 220
         assert state["pa_nozzle_temp"] == 220
+        assert state["tt_start_temp"] == 235
+        assert state["tt_end_temp"] == 205
 
         # Bed temp → all four tabs.
         assert state["tt_bed_temp"] == 65
@@ -801,6 +803,8 @@ class TestApplyIniToSession:
         assert state["em_nozzle_temp"] == 210
         assert state["flow_nozzle_temp"] == 210
         assert state["pa_nozzle_temp"] == 210
+        assert state["tt_start_temp"] == 225
+        assert state["tt_end_temp"] == 195
         assert "tt_bed_temp" not in state
         assert "flow_lh" not in state
 
@@ -854,6 +858,8 @@ class TestApplyIniToSession:
         apply_ini_to_session(state, ini_vals, sidebar=False)
         # Tab keys are written.
         assert state["em_nozzle_temp"] == 230
+        assert state["tt_start_temp"] == 245
+        assert state["tt_end_temp"] == 215
         assert state["pa_bed_temp"] == 70
         # Sidebar keys are NOT written.
         assert "sidebar_nozzle_size" not in state


### PR DESCRIPTION
## Summary

- Temperature tower start/end temp inputs now update automatically when the filament type changes in the sidebar dropdown
- When a PrusaSlicer `.ini` config is loaded, derives a ±15°C range from the INI's nozzle temperature
- Uses the existing `_widget_defaults` mechanism that already handles bed temp, fan speed, etc.

## Test plan

- [x] 786 tests pass, 100% coverage
- [ ] In GUI: change filament type from PLA to PETG — verify start/end temps update to PETG's preset range
- [ ] In GUI: load a `.ini` with `temperature = 240` — verify start=255, end=225

🤖 Generated with [Claude Code](https://claude.com/claude-code)