### PR TITLE
Validate temps against printer hardware limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "cadquery>=2.4",
-    "gcode-lib>=1.1.3",
+    "gcode-lib>=1.1.4",
     "tomli>=2.0; python_version < '3.11'",
 ]
 

--- a/src/filament_calibrator/cli.py
+++ b/src/filament_calibrator/cli.py
@@ -318,6 +318,31 @@ def _resolve_output_dir(
     return Path(tempfile.mkdtemp(prefix=prefix))
 
 
+def _validate_printer_temps(
+    printer_name: Optional[str],
+    nozzle_temp: int,
+    bed_temp: int,
+) -> None:
+    """Exit if temps exceed the selected printer's hardware limits."""
+    if printer_name is None:
+        return
+    specs = gl.PRINTER_PRESETS.get(printer_name)
+    if specs is None:
+        return
+    max_nozzle = specs.get("max_nozzle_temp")
+    max_bed = specs.get("max_bed_temp")
+    if max_nozzle is not None and nozzle_temp > max_nozzle:
+        sys.exit(
+            f"error: nozzle temp {nozzle_temp}°C exceeds {printer_name} "
+            f"max of {int(max_nozzle)}°C"
+        )
+    if max_bed is not None and bed_temp > max_bed:
+        sys.exit(
+            f"error: bed temp {bed_temp}°C exceeds {printer_name} "
+            f"max of {int(max_bed)}°C"
+        )
+
+
 def _resolve_preset(args: argparse.Namespace) -> Dict[str, object]:
     """Look up the filament preset and return resolved settings.
 
@@ -475,6 +500,8 @@ def run(args: argparse.Namespace) -> None:
         if args.bed_center is None:
             args.bed_center = gl.compute_bed_center(printer_name)
         bed_shape = gl.compute_bed_shape(printer_name)
+
+    _validate_printer_temps(printer_name, start_temp, bed_temp)
 
     # Derive layer height and extrusion width from nozzle size.
     nozzle_size: float = args.nozzle_size

--- a/src/filament_calibrator/em_cli.py
+++ b/src/filament_calibrator/em_cli.py
@@ -21,6 +21,7 @@ from filament_calibrator.cli import (
     _explicit_keys,
     _patch_m862_nozzle_flags,
     _resolve_output_dir,
+    _validate_printer_temps,
 )
 from filament_calibrator.config import _find_config_path, load_config
 from filament_calibrator.em_model import EMCubeConfig, generate_em_cube_stl
@@ -256,6 +257,8 @@ def run(args: argparse.Namespace) -> None:
         if args.bed_center is None:
             args.bed_center = gl.compute_bed_center(printer_name)
         bed_shape = gl.compute_bed_shape(printer_name)
+
+    _validate_printer_temps(printer_name, nozzle_temp, bed_temp)
 
     # Derive layer height and extrusion width from nozzle size.
     nozzle_size: float = args.nozzle_size

--- a/src/filament_calibrator/flow_cli.py
+++ b/src/filament_calibrator/flow_cli.py
@@ -19,6 +19,7 @@ from filament_calibrator.cli import (
     _explicit_keys,
     _patch_m862_nozzle_flags,
     _resolve_output_dir,
+    _validate_printer_temps,
 )
 from filament_calibrator.config import _find_config_path, load_config
 from filament_calibrator.flow_insert import compute_flow_levels, insert_flow_rates
@@ -320,6 +321,8 @@ def run(args: argparse.Namespace) -> None:
         if args.bed_center is None:
             args.bed_center = gl.compute_bed_center(printer_name)
         bed_shape = gl.compute_bed_shape(printer_name)
+
+    _validate_printer_temps(printer_name, nozzle_temp, bed_temp)
 
     # Derive layer height and extrusion width from nozzle size.
     nozzle_size: float = args.nozzle_size

--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -86,6 +86,35 @@ def run_pipeline(
     return success, buf.getvalue()
 
 
+def _check_printer_temps(
+    printer: str,
+    nozzle_temp: int,
+    bed_temp: int,
+) -> Optional[str]:
+    """Return an error message if temps exceed the printer's limits, else None."""
+    printer_name: Optional[str]
+    try:
+        printer_name = gl.resolve_printer(printer)
+    except ValueError:
+        return None
+    specs = gl.PRINTER_PRESETS.get(printer_name)
+    if specs is None:
+        return None
+    max_nozzle = specs.get("max_nozzle_temp")
+    max_bed = specs.get("max_bed_temp")
+    if max_nozzle is not None and nozzle_temp > max_nozzle:
+        return (
+            f"Nozzle temp {nozzle_temp}°C exceeds {printer_name} "
+            f"max of {int(max_nozzle)}°C"
+        )
+    if max_bed is not None and bed_temp > max_bed:
+        return (
+            f"Bed temp {bed_temp}°C exceeds {printer_name} "
+            f"max of {int(max_bed)}°C"
+        )
+    return None
+
+
 def build_temp_tower_namespace(
     *,
     filament_type: str,
@@ -761,6 +790,7 @@ def _app() -> None:  # pragma: no cover
     _ini_vals: Dict[str, Any] = {}
     _cur_ini = st.session_state.get("config_ini", "")
     _prev_ini = st.session_state.get("_prev_config_ini", "")
+    _ini_cleared = bool(_prev_ini and not _cur_ini)
     if _cur_ini != _prev_ini:
         st.session_state["_prev_config_ini"] = _cur_ini
         if _cur_ini and Path(_cur_ini).is_file():
@@ -929,7 +959,9 @@ def _app() -> None:  # pragma: no cover
     # explicit values are re-applied afterwards so they always win.
     _prev_ft = st.session_state.get("_preset_filament_type")
     _prev_ns = st.session_state.get("_preset_nozzle_size")
-    _defaults_changed = _prev_ft != filament_type or _prev_ns != nozzle_size
+    _defaults_changed = (
+        _prev_ft != filament_type or _prev_ns != nozzle_size or _ini_cleared
+    )
     if _defaults_changed:
         st.session_state["_preset_filament_type"] = filament_type
         st.session_state["_preset_nozzle_size"] = nozzle_size
@@ -1037,6 +1069,10 @@ def _app() -> None:  # pragma: no cover
 
         if st.button("Generate Temperature Tower", type="primary",
                       key="run_temp"):
+            _temp_err = _check_printer_temps(printer, start_temp, tt_bed_temp)
+            if _temp_err:
+                st.error(_temp_err)
+                st.stop()
             run_dir = _fresh_output_dir(custom_output_dir)
             args = build_temp_tower_namespace(
                 filament_type=filament_type,
@@ -1141,6 +1177,12 @@ def _app() -> None:  # pragma: no cover
 
         if st.button("Generate EM Cube", type="primary",
                       key="run_em"):
+            _temp_err = _check_printer_temps(
+                printer, em_nozzle_temp, em_bed_temp,
+            )
+            if _temp_err:
+                st.error(_temp_err)
+                st.stop()
             run_dir = _fresh_output_dir(custom_output_dir)
             args = build_em_namespace(
                 filament_type=filament_type,
@@ -1274,6 +1316,12 @@ def _app() -> None:  # pragma: no cover
 
         if st.button("Generate Flow Specimen", type="primary",
                       key="run_flow"):
+            _temp_err = _check_printer_temps(
+                printer, flow_nozzle_temp, flow_bed_temp,
+            )
+            if _temp_err:
+                st.error(_temp_err)
+                st.stop()
             run_dir = _fresh_output_dir(custom_output_dir)
             args = build_flow_namespace(
                 filament_type=filament_type,
@@ -1492,6 +1540,12 @@ def _app() -> None:  # pragma: no cover
 
         if st.button("Generate PA Calibration", type="primary",
                       key="run_pa"):
+            _temp_err = _check_printer_temps(
+                printer, pa_nozzle_temp, pa_bed_temp,
+            )
+            if _temp_err:
+                st.error(_temp_err)
+                st.stop()
             run_dir = _fresh_output_dir(custom_output_dir)
             args = build_pa_namespace(
                 filament_type=filament_type,

--- a/src/filament_calibrator/pa_cli.py
+++ b/src/filament_calibrator/pa_cli.py
@@ -24,6 +24,7 @@ from filament_calibrator.cli import (
     _explicit_keys,
     _patch_m862_nozzle_flags,
     _resolve_output_dir,
+    _validate_printer_temps,
 )
 from filament_calibrator.config import _find_config_path, load_config
 from filament_calibrator.pa_insert import (
@@ -384,6 +385,8 @@ def _resolve_common(args: argparse.Namespace) -> dict:
         if args.bed_center is None:
             args.bed_center = gl.compute_bed_center(printer_name)
         bed_shape = gl.compute_bed_shape(printer_name)
+
+    _validate_printer_temps(printer_name, nozzle_temp, bed_temp)
 
     return {
         "num_levels": num_levels,

--- a/src/filament_calibrator/retraction_cli.py
+++ b/src/filament_calibrator/retraction_cli.py
@@ -22,6 +22,7 @@ from filament_calibrator.cli import (
     _explicit_keys,
     _patch_m862_nozzle_flags,
     _resolve_output_dir,
+    _validate_printer_temps,
 )
 from filament_calibrator.config import load_config
 from filament_calibrator.retraction_insert import (
@@ -282,6 +283,8 @@ def _resolve_common(args: argparse.Namespace) -> dict:
         if args.bed_center is None:
             args.bed_center = gl.compute_bed_center(printer_name)
         bed_shape = gl.compute_bed_shape(printer_name)
+
+    _validate_printer_temps(printer_name, nozzle_temp, bed_temp)
 
     return {
         "num_levels": num_levels,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from filament_calibrator.cli import (
     _compute_num_tiers,
     _explicit_keys,
     _patch_m862_nozzle_flags,
+    _validate_printer_temps,
     build_parser,
     main,
     _resolve_preset,
@@ -368,6 +369,58 @@ class TestPatchM862NozzleFlags:
     def test_empty_lines(self):
         result = _patch_m862_nozzle_flags([])
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _validate_printer_temps
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePrinterTemps:
+    def test_none_printer_is_noop(self):
+        _validate_printer_temps(None, 300, 120)  # should not raise
+
+    def test_unknown_printer_is_noop(self):
+        with patch.dict(gl.PRINTER_PRESETS, {}, clear=True):
+            _validate_printer_temps("UNKNOWN", 300, 120)
+
+    def test_nozzle_temp_within_limit(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }, clear=True):
+            _validate_printer_temps("TEST", 290, 100)  # should not raise
+
+    def test_bed_temp_within_limit(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }, clear=True):
+            _validate_printer_temps("TEST", 200, 120)  # should not raise
+
+    def test_nozzle_temp_exceeds_limit(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }, clear=True):
+            with pytest.raises(SystemExit, match="nozzle temp 300.*exceeds TEST max of 290"):
+                _validate_printer_temps("TEST", 300, 100)
+
+    def test_bed_temp_exceeds_limit(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }, clear=True):
+            with pytest.raises(SystemExit, match="bed temp 130.*exceeds TEST max of 120"):
+                _validate_printer_temps("TEST", 200, 130)
+
+    def test_missing_max_nozzle_key_is_noop(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_bed_temp": 120},
+        }, clear=True):
+            _validate_printer_temps("TEST", 999, 100)  # should not raise
+
+    def test_missing_max_bed_key_is_noop(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290},
+        }, clear=True):
+            _validate_printer_temps("TEST", 200, 999)  # should not raise
 
 
 # ---------------------------------------------------------------------------
@@ -1263,6 +1316,34 @@ class TestRun:
         args = self._make_args(tmp_path, printer="NOPE")
         with pytest.raises(SystemExit):
             run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_nozzle_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(
+                tmp_path, start_temp=300, end_temp=295, temp_step=5,
+            )
+            with pytest.raises(SystemExit, match="nozzle temp.*exceeds"):
+                run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_bed_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, bed_temp=130)
+            with pytest.raises(SystemExit, match="bed temp.*exceeds"):
+                run(args)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_em_cli.py
+++ b/tests/test_em_cli.py
@@ -562,6 +562,32 @@ class TestRun:
         with pytest.raises(SystemExit):
             run(args)
 
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_nozzle_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, nozzle_temp=300)
+            with pytest.raises(SystemExit, match="nozzle temp.*exceeds"):
+                run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_bed_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, bed_temp=130)
+            with pytest.raises(SystemExit, match="bed temp.*exceeds"):
+                run(args)
+
 
 # ---------------------------------------------------------------------------
 # main

--- a/tests/test_flow_cli.py
+++ b/tests/test_flow_cli.py
@@ -876,6 +876,32 @@ class TestRun:
         with pytest.raises(SystemExit):
             run(args)
 
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_nozzle_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, nozzle_temp=300)
+            with pytest.raises(SystemExit, match="nozzle temp.*exceeds"):
+                run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_bed_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, bed_temp=130)
+            with pytest.raises(SystemExit, match="bed temp.*exceeds"):
+                run(args)
+
 
 # ---------------------------------------------------------------------------
 # main

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -6,10 +6,13 @@ import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
+import gcode_lib as gl
+
 from filament_calibrator.gui import (
     _FALLBACK_PRESET,
     _NOZZLE_SIZES,
     _PRINTER_LIST,
+    _check_printer_temps,
     _fresh_output_dir,
     _open_directory_dialog,
     _open_file_dialog,
@@ -1129,3 +1132,49 @@ class TestBuildRetractionNamespace:
         assert ns.prusaslicer_path is None
         assert ns.printer_url is None
         assert ns.api_key is None
+
+
+# ---------------------------------------------------------------------------
+# _check_printer_temps
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPrinterTemps:
+    def test_returns_none_when_within_limits(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "COREONE": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            assert _check_printer_temps("COREONE", 250, 60) is None
+
+    def test_nozzle_temp_exceeds(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "COREONE": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            result = _check_printer_temps("COREONE", 300, 60)
+            assert result is not None
+            assert "300" in result
+            assert "290" in result
+
+    def test_bed_temp_exceeds(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "COREONE": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            result = _check_printer_temps("COREONE", 200, 130)
+            assert result is not None
+            assert "130" in result
+            assert "120" in result
+
+    def test_unknown_printer_returns_none(self):
+        with patch("gcode_lib.resolve_printer", side_effect=ValueError("nope")):
+            assert _check_printer_temps("NOPE", 999, 999) is None
+
+    def test_missing_max_keys_returns_none(self):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "COREONE": {},
+        }):
+            assert _check_printer_temps("COREONE", 999, 999) is None
+
+    def test_printer_not_in_presets_returns_none(self):
+        with patch("gcode_lib.resolve_printer", return_value="NEWPRINTER"), \
+             patch.dict(gl.PRINTER_PRESETS, {}, clear=True):
+            assert _check_printer_temps("NEWPRINTER", 999, 999) is None

--- a/tests/test_pa_cli.py
+++ b/tests/test_pa_cli.py
@@ -1134,6 +1134,32 @@ class TestRun:
         with pytest.raises(SystemExit):
             run(args)
 
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_nozzle_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, nozzle_temp=300)
+            with pytest.raises(SystemExit, match="nozzle temp.*exceeds"):
+                run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_bed_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, bed_temp=130)
+            with pytest.raises(SystemExit, match="bed temp.*exceeds"):
+                run(args)
+
 
 # ---------------------------------------------------------------------------
 # Pattern pipeline

--- a/tests/test_retraction_cli.py
+++ b/tests/test_retraction_cli.py
@@ -806,6 +806,32 @@ class TestRun:
             with pytest.raises(SystemExit, match="Unknown printer"):
                 run(args)
 
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_nozzle_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, nozzle_temp=300)
+            with pytest.raises(SystemExit, match="nozzle temp.*exceeds"):
+                run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_bed_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, bed_temp=130)
+            with pytest.raises(SystemExit, match="bed temp.*exceeds"):
+                run(args)
+
     @patch("gcode_lib.patch_slicer_metadata")
     @patch("gcode_lib.inject_thumbnails")
     @patch("filament_calibrator.retraction_cli.gl.save")


### PR DESCRIPTION
## Summary
- Bump gcode-lib to 1.1.4 (adds `max_nozzle_temp` / `max_bed_temp` to `PRINTER_PRESETS`)
- Add `_validate_printer_temps()` shared helper in `cli.py` — exits with clear error if nozzle or bed temp exceeds the selected printer's hardware limits
- Call validation in all 5 CLIs (temp tower, EM, flow, PA, retraction) before model generation
- Add `_check_printer_temps()` to GUI — shows `st.error()` and stops before pipeline runs
- Fix regression: clearing `config_ini` now restores preset defaults for temp tower start/end temps (stale INI-derived values no longer persist)

## Test plan
- [x] 810 tests pass, 100% statement coverage
- [ ] Manual: set nozzle temp above 290°C with COREONE printer, verify CLI exits with error
- [ ] Manual: clear config_ini after loading an INI, verify temp tower start/end temps reset to preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)