### PR TITLE
Fix GCodeLine compatibility in _patch_m862_nozzle_flags

### DIFF
--- a/src/filament_calibrator/cli.py
+++ b/src/filament_calibrator/cli.py
@@ -283,11 +283,11 @@ _M862_PATTERN = re.compile(r"(M862\.1\s+P[\d.]+)(?:\s+A\d)?(?:\s+F\d)?(.*)")
 
 
 def _patch_m862_nozzle_flags(
-    lines: List[str],
+    lines: List[gl.GCodeLine],
     *,
     nozzle_hardened: bool = False,
     nozzle_high_flow: bool = False,
-) -> List[str]:
+) -> List[gl.GCodeLine]:
     """Append ``A`` and ``F`` flags to ``M862.1`` nozzle-check commands.
 
     ``A1`` = hardened/abrasive-resistant nozzle, ``F1`` = high-flow nozzle.
@@ -296,11 +296,13 @@ def _patch_m862_nozzle_flags(
     """
     a_flag = 1 if nozzle_hardened else 0
     f_flag = 1 if nozzle_high_flow else 0
-    result: List[str] = []
+    result: List[gl.GCodeLine] = []
     for line in lines:
-        m = _M862_PATTERN.match(line)
+        raw = line.raw if isinstance(line, gl.GCodeLine) else line
+        m = _M862_PATTERN.match(raw)
         if m:
-            result.append(f"{m.group(1)} A{a_flag} F{f_flag}{m.group(2)}")
+            patched = f"{m.group(1)} A{a_flag} F{f_flag}{m.group(2)}"
+            result.append(gl.parse_line(patched))
         else:
             result.append(line)
     return result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,44 +327,49 @@ class TestResolveOutputDir:
 
 
 class TestPatchM862NozzleFlags:
+    @staticmethod
+    def _raws(lines):
+        return [l.raw if isinstance(l, gl.GCodeLine) else l for l in lines]
+
     def test_no_flags(self):
-        lines = ["M862.1 P0.4", "G28"]
+        lines = [gl.parse_line("M862.1 P0.4"), gl.parse_line("G28")]
         result = _patch_m862_nozzle_flags(lines)
-        assert result == ["M862.1 P0.4 A0 F0", "G28"]
+        assert self._raws(result) == ["M862.1 P0.4 A0 F0", "G28"]
 
     def test_hardened_only(self):
-        lines = ["M862.1 P0.4"]
+        lines = [gl.parse_line("M862.1 P0.4")]
         result = _patch_m862_nozzle_flags(lines, nozzle_hardened=True)
-        assert result == ["M862.1 P0.4 A1 F0"]
+        assert self._raws(result) == ["M862.1 P0.4 A1 F0"]
 
     def test_high_flow_only(self):
-        lines = ["M862.1 P0.6"]
+        lines = [gl.parse_line("M862.1 P0.6")]
         result = _patch_m862_nozzle_flags(lines, nozzle_high_flow=True)
-        assert result == ["M862.1 P0.6 A0 F1"]
+        assert self._raws(result) == ["M862.1 P0.6 A0 F1"]
 
     def test_both_flags(self):
-        lines = ["M862.1 P0.4"]
+        lines = [gl.parse_line("M862.1 P0.4")]
         result = _patch_m862_nozzle_flags(
             lines, nozzle_hardened=True, nozzle_high_flow=True,
         )
-        assert result == ["M862.1 P0.4 A1 F1"]
+        assert self._raws(result) == ["M862.1 P0.4 A1 F1"]
 
     def test_no_m862_lines(self):
-        lines = ["G28", "G1 X10 Y10", "M104 S200"]
+        lines = [gl.parse_line("G28"), gl.parse_line("G1 X10 Y10"),
+                 gl.parse_line("M104 S200")]
         result = _patch_m862_nozzle_flags(lines)
         assert result == lines
 
     def test_idempotent_repatch(self):
-        lines = ["M862.1 P0.4 A0 F0"]
+        lines = [gl.parse_line("M862.1 P0.4 A0 F0")]
         result = _patch_m862_nozzle_flags(
             lines, nozzle_hardened=True, nozzle_high_flow=True,
         )
-        assert result == ["M862.1 P0.4 A1 F1"]
+        assert self._raws(result) == ["M862.1 P0.4 A1 F1"]
 
     def test_preserves_trailing_comment(self):
-        lines = ["M862.1 P0.4 ; nozzle check"]
+        lines = [gl.parse_line("M862.1 P0.4 ; nozzle check")]
         result = _patch_m862_nozzle_flags(lines, nozzle_hardened=True)
-        assert result == ["M862.1 P0.4 A1 F0 ; nozzle check"]
+        assert self._raws(result) == ["M862.1 P0.4 A1 F0 ; nozzle check"]
 
     def test_empty_lines(self):
         result = _patch_m862_nozzle_flags([])


### PR DESCRIPTION
## Summary
- gcode-lib 1.1.4 changed `gf.lines` from `List[str]` to `List[GCodeLine]`, causing `_patch_m862_nozzle_flags` to crash with `expected string or bytes-like object, got 'GCodeLine'`
- Extract `.raw` for regex matching, return `GCodeLine` objects via `gl.parse_line()`
- Update tests to use `GCodeLine` inputs and compare `.raw` outputs

## Test plan
- [x] 810 tests pass, 100% statement coverage
- [ ] Manual: `temperature-tower --filament-type PPA -v --no-upload` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)