### PR TITLE
Populate nozzle flag checkboxes from INI/TOML config

### DIFF
--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -609,6 +609,12 @@ def apply_toml_to_session(
         if pr in _PRINTER_LIST and "_toml_printer" not in state:
             state["_toml_printer"] = pr
 
+    if "nozzle_high_flow" in toml_cfg and "_toml_nozzle_high_flow" not in state:
+        state["_toml_nozzle_high_flow"] = bool(toml_cfg["nozzle_high_flow"])
+
+    if "nozzle_hardened" in toml_cfg and "_toml_nozzle_hardened" not in state:
+        state["_toml_nozzle_hardened"] = bool(toml_cfg["nozzle_hardened"])
+
 
 # ---------------------------------------------------------------------------
 # INI auto-populate helpers
@@ -692,6 +698,12 @@ def apply_ini_to_session(
     if sidebar and "filament_type" in ini_vals:
         ft = ini_vals["filament_type"].upper()
         state["sidebar_filament_type"] = ft
+
+    if sidebar and "nozzle_high_flow" in ini_vals:
+        state["sidebar_nozzle_high_flow"] = ini_vals["nozzle_high_flow"]
+
+    if sidebar and "nozzle_hardened" in ini_vals:
+        state["sidebar_nozzle_hardened"] = ini_vals["nozzle_hardened"]
 
 
 # ---------------------------------------------------------------------------
@@ -825,6 +837,14 @@ def _app() -> None:  # pragma: no cover
         st.session_state["sidebar_nozzle_size"] = (
             st.session_state.get("_toml_nozzle_size", 0.4)
         )
+    if "sidebar_nozzle_high_flow" not in st.session_state:
+        st.session_state["sidebar_nozzle_high_flow"] = (
+            st.session_state.get("_toml_nozzle_high_flow", False)
+        )
+    if "sidebar_nozzle_hardened" not in st.session_state:
+        st.session_state["sidebar_nozzle_hardened"] = (
+            st.session_state.get("_toml_nozzle_hardened", False)
+        )
 
     # --- Sidebar: shared settings ---
     with st.sidebar:
@@ -859,12 +879,12 @@ def _app() -> None:  # pragma: no cover
         with _nozzle_col:
             nozzle_high_flow = st.checkbox(
                 "High Flow",
-                value=False,
+                key="sidebar_nozzle_high_flow",
                 help="Nozzle is a high-flow variant (sets F flag in M862.1)",
             )
             nozzle_hardened = st.checkbox(
                 "Hardened",
-                value=False,
+                key="sidebar_nozzle_hardened",
                 help="Nozzle is hardened/abrasive-resistant (sets A flag in M862.1)",
             )
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -766,6 +766,8 @@ class TestApplyIniToSession:
             "nozzle_diameter": 0.4,
             "printer_model": "COREONE",
             "bed_center": "125,110",
+            "nozzle_high_flow": True,
+            "nozzle_hardened": True,
         }
         apply_ini_to_session(state, ini_vals)
 
@@ -804,6 +806,10 @@ class TestApplyIniToSession:
         # Selectbox widget keys (written directly for Streamlit key= binding).
         assert state["sidebar_nozzle_size"] == 0.4
         assert state["sidebar_printer"] == "COREONE"
+
+        # Nozzle flags → sidebar checkboxes.
+        assert state["sidebar_nozzle_high_flow"] is True
+        assert state["sidebar_nozzle_hardened"] is True
 
     def test_partial_dict_only_temp(self) -> None:
         state: dict = {}
@@ -854,6 +860,21 @@ class TestApplyIniToSession:
         apply_ini_to_session(state, {"filament_type": "POM"})
         assert state["sidebar_filament_type"] == "POM"
 
+    def test_nozzle_flags_set(self) -> None:
+        state: dict = {}
+        apply_ini_to_session(
+            state,
+            {"nozzle_high_flow": True, "nozzle_hardened": False},
+        )
+        assert state["sidebar_nozzle_high_flow"] is True
+        assert state["sidebar_nozzle_hardened"] is False
+
+    def test_nozzle_flags_missing(self) -> None:
+        state: dict = {}
+        apply_ini_to_session(state, {"nozzle_temp": 210})
+        assert "sidebar_nozzle_high_flow" not in state
+        assert "sidebar_nozzle_hardened" not in state
+
     def test_sidebar_false_skips_sidebar_keys(self) -> None:
         """sidebar=False skips sidebar widget keys (post-render re-apply)."""
         state: dict = {}
@@ -863,6 +884,8 @@ class TestApplyIniToSession:
             "nozzle_diameter": 0.6,
             "printer_model": "COREONE",
             "filament_type": "PETG",
+            "nozzle_high_flow": True,
+            "nozzle_hardened": True,
         }
         apply_ini_to_session(state, ini_vals, sidebar=False)
         # Tab keys are written.
@@ -874,6 +897,8 @@ class TestApplyIniToSession:
         assert "sidebar_nozzle_size" not in state
         assert "sidebar_printer" not in state
         assert "sidebar_filament_type" not in state
+        assert "sidebar_nozzle_high_flow" not in state
+        assert "sidebar_nozzle_hardened" not in state
 
 
 # ---------------------------------------------------------------------------
@@ -952,6 +977,25 @@ class TestApplyTomlToSession:
         state = {"_toml_filament_type": "PLA"}
         apply_toml_to_session(state, {"filament_type": "ABS"})
         assert state["_toml_filament_type"] == "PLA"
+
+    def test_nozzle_flags_set(self) -> None:
+        state: dict = {}
+        apply_toml_to_session(
+            state, {"nozzle_high_flow": True, "nozzle_hardened": True}
+        )
+        assert state["_toml_nozzle_high_flow"] is True
+        assert state["_toml_nozzle_hardened"] is True
+
+    def test_nozzle_flags_not_overwritten(self) -> None:
+        state = {
+            "_toml_nozzle_high_flow": False,
+            "_toml_nozzle_hardened": False,
+        }
+        apply_toml_to_session(
+            state, {"nozzle_high_flow": True, "nozzle_hardened": True}
+        )
+        assert state["_toml_nozzle_high_flow"] is False
+        assert state["_toml_nozzle_hardened"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bind High Flow and Hardened nozzle checkboxes to session state keys (`sidebar_nozzle_high_flow`, `sidebar_nozzle_hardened`)
- `apply_ini_to_session()` now sets nozzle flag checkboxes when loading a PrusaSlicer `.ini` config
- `apply_toml_to_session()` now sets nozzle flag defaults from TOML config
- Requires gcode-lib >= 1.1.5 (hyiger/gcode-lib#26)

## Test plan
- [x] 818 tests pass with 100% coverage
- [ ] Load a PrusaSlicer `.ini` with `nozzle_high_flow = 1` and `filament_abrasive = 1` — verify checkboxes are checked
- [ ] Load a TOML config with `nozzle_high_flow = true` — verify checkbox is checked on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)