### PR TITLE
Fix retraction test slicing when config has wipe enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,9 +146,11 @@ override the preset.  Unknown filament names fall back to safe defaults
   `--support-material=0`.
 - `RETRACTION_SLICER_ARGS` — for retraction test tower slicing
   (2 perimeters, 15% infill).  `slice_retraction_specimen()` always
-  forces `--use-firmware-retraction` so PrusaSlicer emits G10/G11
-  instead of explicit retract moves, allowing M207 commands to control
-  the retraction length.
+  forces `--use-firmware-retraction` and `--wipe=0` so PrusaSlicer
+  emits G10/G11 instead of explicit retract moves, allowing M207
+  commands to control the retraction length.  Wipe must be disabled
+  because PrusaSlicer considers it incompatible with firmware
+  retraction.
 
 All slicer functions accept `nozzle_diameter` to pass `--nozzle-diameter` to
 PrusaSlicer, and pass `--center` and `--bed-shape` for Prusa MK-series bed

--- a/src/filament_calibrator/slicer.py
+++ b/src/filament_calibrator/slicer.py
@@ -733,6 +733,10 @@ def slice_retraction_specimen(
         # Always force firmware retraction so M207 controls retraction
         # length, even when a user-supplied config.ini is loaded.
         "--use-firmware-retraction",
+        # Wipe is incompatible with firmware retraction in PrusaSlicer;
+        # force it off so user configs that enable wipe don't cause a
+        # slicing error.
+        "--wipe=0",
     ]
     if binary_gcode:
         cli_extra.append("--binary-gcode")

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1920,7 +1920,7 @@ class TestSliceRetractionSpecimen:
     @patch("filament_calibrator.slicer.gl.slice_model")
     @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
     def test_firmware_retraction_always_enabled(self, mock_find, mock_slice):
-        """--use-firmware-retraction is always added, even with config_ini."""
+        """--use-firmware-retraction and --wipe=0 always added."""
         mock_find.return_value = "/usr/bin/prusa-slicer"
         mock_slice.return_value = gl.RunResult(
             cmd=[], returncode=0, stdout="", stderr=""
@@ -1930,6 +1930,7 @@ class TestSliceRetractionSpecimen:
         slice_retraction_specimen("/tmp/t.stl", "/tmp/t.gcode")
         req = mock_slice.call_args[0][1]
         assert "--use-firmware-retraction" in req.extra_args
+        assert "--wipe=0" in req.extra_args
 
         # With config_ini
         slice_retraction_specimen(
@@ -1937,6 +1938,7 @@ class TestSliceRetractionSpecimen:
         )
         req = mock_slice.call_args[0][1]
         assert "--use-firmware-retraction" in req.extra_args
+        assert "--wipe=0" in req.extra_args
 
     @patch("filament_calibrator.slicer.gl.slice_model")
     @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")


### PR DESCRIPTION
## Summary
- Force `--wipe=0` alongside `--use-firmware-retraction` in `slice_retraction_specimen()` to prevent PrusaSlicer from failing with "not compatible with --wipe" when the user's config INI enables wipe
- Updated CLAUDE.md slicer docs to mention the wipe override

## Test plan
- [x] 818 tests pass with 100% coverage
- [ ] Run `retraction-test --config-ini <config-with-wipe-enabled>` — should slice successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)