### PR TITLE
Add shrinkage-test calibration tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 **filament-calibrator** is a CLI tool suite for 3D printer filament calibration.
-It contains five tools:
+It contains six tools:
 
 - `temperature-tower` — generates, slices, and uploads temperature tower prints
   to find the optimal printing temperature for a filament.
@@ -27,6 +27,11 @@ It contains five tools:
   height level the firmware retraction length is changed via
   `M207 S<length>`, so the user can inspect stringing at each height to
   find the optimal retraction distance.
+- `shrinkage-test` — generates a parametric 3-axis cross specimen
+  (three perpendicular arms with window cutouts and axis labels),
+  slices it with standard settings, and uploads.  The user prints
+  the cross, measures each arm with calipers, and calculates
+  per-axis shrinkage: `shrinkage % = (nominal − measured) / nominal × 100`.
 
 ## Architecture
 
@@ -41,7 +46,7 @@ src/filament_calibrator/
   model.py          # CadQuery parametric temperature tower model
   slicer.py         # PrusaSlicer CLI wrapper (slice_tower, slice_flow_specimen,
                     #   slice_pa_specimen, slice_em_specimen,
-                    #   slice_retraction_specimen)
+                    #   slice_retraction_specimen, slice_shrinkage_specimen)
   tempinsert.py     # G-code temperature command insertion
   em_cli.py         # extrusion-multiplier argparse CLI, pipeline orchestration
   em_model.py       # CadQuery parametric cube model for EM calibration
@@ -59,7 +64,9 @@ src/filament_calibrator/
   retraction_cli.py   # retraction-test argparse CLI, pipeline orchestration
   retraction_model.py # CadQuery parametric two-tower retraction test model
   retraction_insert.py # G-code M207 retraction length command insertion
-  gui.py            # Streamlit browser GUI wrapping all five CLIs
+  shrinkage_cli.py    # shrinkage-test argparse CLI, pipeline orchestration
+  shrinkage_model.py  # CadQuery parametric 3-axis cross model for shrinkage
+  gui.py            # Streamlit browser GUI wrapping all six CLIs
 ```
 
 ### Key Dependencies
@@ -114,9 +121,16 @@ generate_retraction_tower_stl → slice_retraction_specimen
 patch_slicer_metadata → compute_retraction_levels →
 insert_retraction_commands (M207) → save → optional upload.
 
+**shrinkage-test** (`shrinkage_cli.run()`):
+load_config → apply_config → resolve_preset →
+generate_shrinkage_cross_stl → slice_shrinkage_specimen
+(standard slicing) → load G-code → inject_thumbnails →
+patch_slicer_metadata → save →
+print expected dimensions → optional upload.
+
 ### Filament Preset System
 
-All five CLIs use `--filament-type` to look up defaults from
+All six CLIs use `--filament-type` to look up defaults from
 `gcode_lib.FILAMENT_PRESETS`.  Known presets (PLA, PETG, ABS, ASA, TPU, etc.)
 automatically set nozzle temperature, bed temperature, and fan speed.
 Explicit CLI arguments (`--nozzle-temp`, `--bed-temp`, `--fan-speed`)
@@ -151,6 +165,9 @@ override the preset.  Unknown filament names fall back to safe defaults
   commands to control the retraction length.  Wipe must be disabled
   because PrusaSlicer considers it incompatible with firmware
   retraction.
+- `SHRINKAGE_SLICER_ARGS` — for shrinkage cross slicing (3 perimeters,
+  20% infill, 5 top / 4 bottom solid layers).  Standard slicing for
+  dimensional accuracy — no vase mode, no firmware retraction.
 
 All slicer functions accept `nozzle_diameter` to pass `--nozzle-diameter` to
 PrusaSlicer, and pass `--center` and `--bed-shape` for Prusa MK-series bed
@@ -174,7 +191,8 @@ thumbnail previews.  Use `--ascii-gcode` on the CLI to switch to text
 - Filament preset lookup is case-insensitive (`.upper()`)
 - Shared CLI helpers (`_apply_config`, `_resolve_output_dir`, `_UNSET`,
   `_KNOWN_TYPES`, `_ARGPARSE_DEFAULTS`) live in `cli.py` and are imported
-  by `em_cli.py`, `flow_cli.py`, `pa_cli.py`, and `retraction_cli.py`.
+  by `em_cli.py`, `flow_cli.py`, `pa_cli.py`, `retraction_cli.py`,
+  and `shrinkage_cli.py`.
   Generic filename/preset
   helpers (`unique_suffix`, `safe_filename_part`, `gcode_ext`,
   `resolve_filament_preset`) are imported from `gcode_lib`.
@@ -205,6 +223,7 @@ Entry points:
 - `volumetric-flow` → `filament_calibrator.flow_cli:main`
 - `pressure-advance` → `filament_calibrator.pa_cli:main`
 - `retraction-test` → `filament_calibrator.retraction_cli:main`
+- `shrinkage-test` → `filament_calibrator.shrinkage_cli:main`
 - `filament-calibrator-gui` → `filament_calibrator.gui:main` (requires `[gui]` extra)
 
 ## Common Tasks
@@ -224,10 +243,13 @@ Entry points:
 - **Change retraction tower geometry**: Edit constants in
   `retraction_model.py` (TOWER_DIAMETER, TOWER_SPACING, BASE_LENGTH,
   BASE_WIDTH, BASE_HEIGHT, LEVEL_HEIGHT).
+- **Change shrinkage cross geometry**: Edit constants in
+  `shrinkage_model.py` (ARM_LENGTH, ARM_SIZE, WINDOW_SIZE,
+  WINDOW_INTERVAL, LABEL_DEPTH, LABEL_FONT_SIZE).
 - **Change slicer defaults**: Edit `DEFAULT_SLICER_ARGS` (temp tower),
   `VASE_MODE_SLICER_ARGS` (flow specimen), `PA_SLICER_ARGS` (PA tower),
-  `EM_SLICER_ARGS` (EM cube), or `RETRACTION_SLICER_ARGS` (retraction
-  towers) in `slicer.py`.
+  `EM_SLICER_ARGS` (EM cube), `RETRACTION_SLICER_ARGS` (retraction
+  towers), or `SHRINKAGE_SLICER_ARGS` (shrinkage cross) in `slicer.py`.
 - **Add a new calibration tool**: Create a new module + CLI entry point in
   `pyproject.toml [project.scripts]`.  Import shared helpers from `cli.py`.
 - **Add a new config key**: Add to `CONFIG_KEYS` in `config.py`, add

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CLI tool suite for 3D printer filament calibration on Prusa printers.
 - **[Volumetric Flow](docs/volumetric-flow.md)** — determine maximum volumetric flow rate for a filament/hotend combination
 - **[Pressure Advance](docs/pressure-advance.md)** — find the optimal PA/Linear Advance value (tower or chevron pattern method)
 - **[Retraction Test](docs/retraction-test.md)** — find the optimal retraction distance by inspecting stringing between two towers
+- **[Shrinkage Test](docs/shrinkage.md)** — measure per-axis shrinkage (X/Y/Z) by printing a 3-axis calibration cross
 
 ## Quick Start
 
@@ -29,7 +30,7 @@ run.
 
 ## GUI
 
-A [Streamlit browser GUI](docs/gui.md) wraps all five tools:
+A [Streamlit browser GUI](docs/gui.md) wraps all six tools:
 
 ```bash
 pip install -e ".[gui]"

--- a/docs/shrinkage.md
+++ b/docs/shrinkage.md
@@ -1,0 +1,137 @@
+# Shrinkage Test
+
+Generates a parametric 3-axis calibration cross, slices it with standard
+settings, and uploads. Print the cross, measure each arm with calipers, and
+calculate per-axis shrinkage:
+`shrinkage % = (nominal − measured) / nominal × 100`.
+
+## Quick Start
+
+Generate a PLA shrinkage cross with default settings:
+
+```bash
+shrinkage-test --no-upload --output-dir ./output --keep-files
+```
+
+Upload directly to printer:
+
+```bash
+shrinkage-test \
+  --printer-url http://192.168.1.100 \
+  --api-key YOUR_API_KEY
+```
+
+## How It Works
+
+1. **Model generation** — CadQuery builds a 3-axis cross: three perpendicular
+   rectangular arms (X, Y, Z) meeting at a centre block, each 100 mm long with
+   a 10 × 10 mm square cross-section. Square window cutouts at 20 mm intervals
+   reduce material usage and print time. Embossed X/Y/Z labels identify each
+   axis.
+
+2. **Slicing** — PrusaSlicer slices with standard settings (3 perimeters,
+   20% infill, 5 top / 4 bottom solid layers) for dimensional accuracy.
+
+3. **Expected dimensions** — The tool prints the nominal arm length for each
+   axis (default 100 mm).
+
+4. **Upload** — Same PrusaLink upload path as the other tools.
+
+## Interpreting the Print
+
+Print the cross, then measure each arm length with digital calipers:
+
+- **X arm** — horizontal arm labelled "X"
+- **Y arm** — horizontal arm labelled "Y"
+- **Z arm** — vertical arm labelled "Z"
+
+Calculate per-axis shrinkage:
+
+```
+shrinkage_x = (nominal - measured_x) / nominal * 100
+shrinkage_y = (nominal - measured_y) / nominal * 100
+shrinkage_z = (nominal - measured_z) / nominal * 100
+```
+
+For example, if nominal is 100 mm and you measure X=99.2, Y=99.4, Z=99.0:
+
+- X shrinkage = (100 − 99.2) / 100 × 100 = **0.8%**
+- Y shrinkage = (100 − 99.4) / 100 × 100 = **0.6%**
+- Z shrinkage = (100 − 99.0) / 100 × 100 = **1.0%**
+
+Materials like ABS, ASA, Nylon, and PC typically show 0.5–2% shrinkage.
+PLA and PETG usually show minimal shrinkage (< 0.5%).
+
+## CLI Reference
+
+### Model Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--filament-type` | `PLA` | Filament type (preset name or custom) |
+| `--arm-length` | `100.0` | Length of each arm in mm |
+
+### Nozzle Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--nozzle-size` | `0.4` | Nozzle diameter in mm — derives layer height (`nozzle × 0.5`) and extrusion width (`nozzle × 1.125`) |
+| `--nozzle-high-flow` | `false` | Nozzle is a high-flow variant (sets F flag in M862.1) |
+| `--nozzle-hardened` | `false` | Nozzle is hardened/abrasive-resistant (sets A flag in M862.1) |
+
+### Slicer Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--nozzle-temp` | from preset | Nozzle temperature (deg C) — overrides preset |
+| `--bed-temp` | from preset | Bed temperature (deg C) — overrides preset |
+| `--fan-speed` | from preset | Fan speed (0--100%) — overrides preset |
+| `--layer-height` | from `--nozzle-size` | Slicer layer height in mm (default: nozzle × 0.5) |
+| `--extrusion-width` | from `--nozzle-size` | Slicer extrusion width in mm (default: nozzle × 1.125) |
+| `--config-ini` | | PrusaSlicer `.ini` config file |
+| `--prusaslicer-path` | auto-detect | Path to PrusaSlicer executable |
+| `--printer` | `COREONE` | Printer model — auto-sets bed center/shape and embeds printer metadata in bgcode |
+| `--bed-center` | from `--printer` | Bed centre as X,Y in mm (auto-set by `--printer`) |
+| `--extra-slicer-args` | | Additional PrusaSlicer CLI args (must be last) |
+
+Supported printers for `--printer`: **COREONE**, **COREONEL**, **MK4S**
+(alias: MK4), **MINI**, **XL**.
+
+### Printer Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--printer-url` | | PrusaLink URL (e.g. `http://192.168.1.100`) |
+| `--api-key` | | PrusaLink API key |
+| `--no-upload` | `false` | Skip uploading to printer |
+| `--print-after-upload` | `false` | Start printing after upload |
+
+### Output Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output-dir` | temp dir | Directory for output files |
+| `--keep-files` | `false` | Keep intermediate STL and raw G-code |
+| `--ascii-gcode` | `false` | Output ASCII `.gcode` instead of binary `.bgcode` |
+| `--config` | auto-detect | Path to a TOML config file |
+| `-v`, `--verbose` | `false` | Show detailed debug output |
+
+## Examples
+
+ABS with custom temperature (ABS typically shrinks 0.5–1%):
+
+```bash
+shrinkage-test --filament-type ABS --nozzle-temp 250 --bed-temp 100 --no-upload
+```
+
+With a 0.6mm nozzle (auto-sets 0.3mm layer height, 0.68mm extrusion width):
+
+```bash
+shrinkage-test --nozzle-size 0.6 --no-upload
+```
+
+Custom arm length (shorter arms for faster print):
+
+```bash
+shrinkage-test --arm-length 80 --no-upload
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ extrusion-multiplier = "filament_calibrator.em_cli:main"
 volumetric-flow = "filament_calibrator.flow_cli:main"
 pressure-advance = "filament_calibrator.pa_cli:main"
 retraction-test = "filament_calibrator.retraction_cli:main"
+shrinkage-test = "filament_calibrator.shrinkage_cli:main"
 filament-calibrator-gui = "filament_calibrator.gui:main"
 
 [tool.hatch.build.targets.wheel]

--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -406,6 +406,57 @@ def build_retraction_namespace(
     )
 
 
+def build_shrinkage_namespace(
+    *,
+    filament_type: str,
+    arm_length: float,
+    nozzle_temp: int,
+    bed_temp: int,
+    fan_speed: int,
+    nozzle_size: float,
+    nozzle_high_flow: bool = False,
+    nozzle_hardened: bool = False,
+    layer_height: float,
+    extrusion_width: float,
+    printer: str,
+    ascii_gcode: bool,
+    output_dir: str,
+    config_ini: Optional[str],
+    prusaslicer_path: Optional[str],
+    printer_url: Optional[str],
+    api_key: Optional[str],
+    no_upload: bool,
+    print_after_upload: bool,
+) -> argparse.Namespace:
+    """Build an ``argparse.Namespace`` for the shrinkage-test pipeline."""
+    return argparse.Namespace(
+        filament_type=filament_type,
+        arm_length=arm_length,
+        nozzle_temp=nozzle_temp,
+        bed_temp=bed_temp,
+        fan_speed=fan_speed,
+        nozzle_size=nozzle_size,
+        nozzle_high_flow=nozzle_high_flow,
+        nozzle_hardened=nozzle_hardened,
+        layer_height=layer_height,
+        extrusion_width=extrusion_width,
+        printer=printer,
+        ascii_gcode=ascii_gcode,
+        output_dir=output_dir,
+        config_ini=config_ini or None,
+        prusaslicer_path=prusaslicer_path or None,
+        bed_center=None,
+        extra_slicer_args=None,
+        printer_url=printer_url or None,
+        api_key=api_key or None,
+        no_upload=no_upload,
+        print_after_upload=print_after_upload,
+        config=None,
+        keep_files=True,
+        verbose=True,
+    )
+
+
 def _fresh_output_dir(custom_output_dir: str) -> str:
     """Return *custom_output_dir* if set, otherwise a fresh temp directory.
 
@@ -782,6 +833,7 @@ def _app() -> None:  # pragma: no cover
     from filament_calibrator.flow_cli import run as flow_run
     from filament_calibrator.pa_cli import run as pa_run
     from filament_calibrator.retraction_cli import run as retraction_run
+    from filament_calibrator.shrinkage_cli import run as shrinkage_run
 
     st.set_page_config(
         page_title="Filament Calibrator",
@@ -1020,6 +1072,11 @@ def _app() -> None:  # pragma: no cover
         "retraction_fan": preset["fan"],
         "retraction_lh": derived_lh,
         "retraction_ew": derived_ew,
+        "shrinkage_nozzle_temp": preset["hotend"],
+        "shrinkage_bed_temp": preset["bed"],
+        "shrinkage_fan": preset["fan"],
+        "shrinkage_lh": derived_lh,
+        "shrinkage_ew": derived_ew,
     }
     for _wk, _wv in _widget_defaults.items():
         if _wk not in st.session_state or _defaults_changed:
@@ -1032,9 +1089,10 @@ def _app() -> None:  # pragma: no cover
         apply_ini_to_session(st.session_state, _ini_vals, sidebar=False)
 
     # --- Tabs ---
-    tab_temp, tab_em, tab_flow, tab_pa, tab_retraction, tab_results = st.tabs([
+    (tab_temp, tab_em, tab_flow, tab_pa, tab_retraction,
+     tab_shrinkage, tab_results) = st.tabs([
         "Temperature Tower", "Extrusion Multiplier", "Volumetric Flow",
-        "Pressure Advance", "Retraction Test", "Results",
+        "Pressure Advance", "Retraction Test", "Shrinkage", "Results",
     ])
 
     # === Tab 1: Temperature Tower ===
@@ -1781,7 +1839,120 @@ def _app() -> None:  # pragma: no cover
         if _run and _run["tab"] == "retraction":
             _show_results(st, _run)
 
-    # === Tab 6: Calibration Results ===
+    # === Tab 6: Shrinkage ===
+    with tab_shrinkage:
+        st.subheader("Shrinkage Test")
+        st.caption(
+            "Generate a 3-axis calibration cross. Print it, measure each "
+            "arm with calipers, and calculate: "
+            "shrinkage = (nominal \u2212 measured) / nominal \u00d7 100."
+        )
+
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            shrinkage_nozzle_temp = st.number_input(
+                "Nozzle Temp (\u00b0C)",
+                min_value=150,
+                max_value=350,
+                key="shrinkage_nozzle_temp",
+            )
+        with col2:
+            shrinkage_bed_temp = st.number_input(
+                "Bed Temp (\u00b0C)",
+                min_value=0,
+                max_value=150,
+                key="shrinkage_bed_temp",
+            )
+        with col3:
+            shrinkage_fan = st.number_input(
+                "Fan Speed (%)",
+                min_value=0,
+                max_value=100,
+                key="shrinkage_fan",
+            )
+
+        with st.expander("Advanced Slicer Settings"):
+            shrinkage_arm_length = st.number_input(
+                "Arm Length (mm)",
+                value=100.0,
+                min_value=20.0,
+                max_value=200.0,
+                step=10.0,
+                key="shrinkage_arm_length",
+            )
+            shrinkage_layer_height = st.number_input(
+                "Layer Height (mm)",
+                min_value=0.05,
+                max_value=1.0,
+                format="%.2f",
+                key="shrinkage_lh",
+            )
+            shrinkage_extrusion_width = st.number_input(
+                "Extrusion Width (mm)",
+                min_value=0.1,
+                max_value=2.0,
+                format="%.2f",
+                key="shrinkage_ew",
+            )
+
+        st.info(
+            f"Expected dimensions: X={shrinkage_arm_length:.1f}  "
+            f"Y={shrinkage_arm_length:.1f}  "
+            f"Z={shrinkage_arm_length:.1f} mm"
+        )
+
+        if st.button("Generate Shrinkage Cross", type="primary",
+                      key="run_shrinkage"):
+            _temp_err = _check_printer_temps(
+                printer, shrinkage_nozzle_temp, shrinkage_bed_temp,
+            )
+            if _temp_err:
+                st.error(_temp_err)
+                st.stop()
+            run_dir = _fresh_output_dir(custom_output_dir)
+            args = build_shrinkage_namespace(
+                filament_type=filament_type,
+                arm_length=shrinkage_arm_length,
+                nozzle_temp=shrinkage_nozzle_temp,
+                bed_temp=shrinkage_bed_temp,
+                fan_speed=shrinkage_fan,
+                nozzle_size=nozzle_size,
+                nozzle_high_flow=nozzle_high_flow,
+                nozzle_hardened=nozzle_hardened,
+                layer_height=shrinkage_layer_height,
+                extrusion_width=shrinkage_extrusion_width,
+                printer=printer,
+                ascii_gcode=ascii_gcode,
+                output_dir=run_dir,
+                config_ini=config_ini,
+                prusaslicer_path=prusaslicer_path,
+                printer_url=None,
+                api_key=None,
+                no_upload=True,
+                print_after_upload=False,
+            )
+            with st.spinner("Running shrinkage test pipeline..."):
+                success, log = run_pipeline(shrinkage_run, args)
+            st.session_state["_last_run"] = {
+                "output_dir": run_dir,
+                "ascii_gcode": ascii_gcode,
+                "success": success,
+                "log": log,
+                "tab": "shrinkage",
+                "upload_enabled": enable_upload,
+                "printer_url": printer_url,
+                "api_key": api_key,
+            }
+            st.session_state.pop("_upload_status", None)
+            st.session_state.pop("_upload_message", None)
+            st.session_state.pop("_print_after", None)
+            st.session_state.pop("upload_print_after", None)
+
+        _run = st.session_state.get("_last_run")
+        if _run and _run["tab"] == "shrinkage":
+            _show_results(st, _run)
+
+    # === Tab 7: Calibration Results ===
     with tab_results:
         st.subheader("Calibration Results")
         st.markdown(

--- a/src/filament_calibrator/shrinkage_cli.py
+++ b/src/filament_calibrator/shrinkage_cli.py
@@ -1,0 +1,402 @@
+"""Command-line interface for shrinkage calibration.
+
+Orchestrates: model generation → standard slicing → thumbnail injection → upload.
+No G-code parameter insertion is needed — the user prints the cross,
+measures X/Y/Z arm lengths with calipers, and calculates per-axis shrinkage.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import gcode_lib as gl
+
+from filament_calibrator.cli import (
+    _ARGPARSE_DEFAULTS,
+    _KNOWN_TYPES,
+    _UNSET,
+    _apply_config,
+    _explicit_keys,
+    _patch_m862_nozzle_flags,
+    _resolve_output_dir,
+    _validate_printer_temps,
+)
+from filament_calibrator.config import _find_config_path, load_config
+from filament_calibrator.shrinkage_model import (
+    ShrinkageCrossConfig,
+    generate_shrinkage_cross_stl,
+)
+from filament_calibrator.slicer import (
+    DEFAULT_BED_CENTER,
+    DEFAULT_THUMBNAILS,
+    slice_shrinkage_specimen,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    p = argparse.ArgumentParser(
+        prog="shrinkage-test",
+        description=(
+            "Generate, slice, and upload a shrinkage calibration cross. "
+            "Print the cross, measure X/Y/Z arm lengths with calipers, and "
+            "calculate: shrinkage = (nominal - measured) / nominal * 100."
+        ),
+    )
+
+    # --- Model options ---
+    type_names = ", ".join(_KNOWN_TYPES)
+    model = p.add_argument_group("model options")
+    model.add_argument(
+        "--filament-type", type=str, default="PLA",
+        help=(
+            f"Filament type. Known presets ({type_names}) set defaults "
+            "for --nozzle-temp, --bed-temp, and --fan-speed automatically. "
+            "Custom names are accepted but require explicit temperatures. "
+            "Default: PLA"
+        ),
+    )
+    model.add_argument(
+        "--arm-length", type=float, default=100.0,
+        help="Length of each arm of the calibration cross in mm. Default: 100.0",
+    )
+
+    # --- Nozzle options ---
+    nozzle = p.add_argument_group("nozzle options")
+    nozzle.add_argument(
+        "--nozzle-size", type=float, default=0.4,
+        help=(
+            "Nozzle diameter in mm. Sets defaults for "
+            "--layer-height (nozzle × 0.5) and --extrusion-width "
+            "(nozzle × 1.125) when they are not explicitly provided. "
+            "Default: 0.4"
+        ),
+    )
+    nozzle.add_argument(
+        "--nozzle-high-flow", action="store_true", default=False,
+        help="Nozzle is a high-flow variant (sets F flag in M862.1).",
+    )
+    nozzle.add_argument(
+        "--nozzle-hardened", action="store_true", default=False,
+        help="Nozzle is hardened/abrasive-resistant (sets A flag in M862.1).",
+    )
+
+    # --- Slicer options ---
+    slicer = p.add_argument_group("slicer options")
+    slicer.add_argument(
+        "--layer-height", type=float, default=_UNSET,
+        help=(
+            "Slicer layer height in mm. Default: derived from "
+            "--nozzle-size (nozzle × 0.5)."
+        ),
+    )
+    slicer.add_argument(
+        "--extrusion-width", type=float, default=_UNSET,
+        help=(
+            "Slicer extrusion width in mm. Default: derived from "
+            "--nozzle-size (nozzle × 1.125)."
+        ),
+    )
+    slicer.add_argument(
+        "--bed-temp", type=int, default=_UNSET,
+        help=(
+            "Bed temperature in °C. Overrides the default from "
+            "--filament-type preset."
+        ),
+    )
+    slicer.add_argument(
+        "--fan-speed", type=int, default=_UNSET,
+        help=(
+            "Fan speed 0–100%%. Overrides the default from "
+            "--filament-type preset."
+        ),
+    )
+    slicer.add_argument(
+        "--nozzle-temp", type=int, default=_UNSET,
+        help=(
+            "Nozzle temperature in °C. Overrides the default from "
+            "--filament-type preset."
+        ),
+    )
+    slicer.add_argument(
+        "--config-ini", type=str, default=None,
+        help="PrusaSlicer .ini config file. If omitted, built-in defaults are used.",
+    )
+    slicer.add_argument(
+        "--prusaslicer-path", type=str, default=None,
+        help="Explicit path to PrusaSlicer executable.",
+    )
+    slicer.add_argument(
+        "--bed-center", type=str, default=None,
+        help=(
+            "Bed centre as X,Y in mm (e.g. 125,110). Default: 125,110 "
+            "(Prusa MK-series)."
+        ),
+    )
+    slicer.add_argument(
+        "--extra-slicer-args", type=str, nargs=argparse.REMAINDER, default=None,
+        help="Additional raw CLI arguments for PrusaSlicer (must be last).",
+    )
+
+    # --- Printer model ---
+    printer_names = ", ".join(sorted(gl.KNOWN_PRINTERS))
+    p.add_argument(
+        "--printer", type=str, default="COREONE",
+        help=(
+            f"Printer model for bed dimensions and metadata. "
+            f"Available: {printer_names} (also accepts mk4 as alias for mk4s). "
+            "Auto-sets --bed-center and bed shape from the printer's preset."
+        ),
+    )
+
+    # --- Printer / upload options ---
+    printer = p.add_argument_group("printer options")
+    printer.add_argument(
+        "--printer-url", type=str, default=None,
+        help="PrusaLink printer URL (e.g. http://192.168.1.100).",
+    )
+    printer.add_argument(
+        "--api-key", type=str, default=None,
+        help="PrusaLink API key.",
+    )
+    printer.add_argument(
+        "--no-upload", action="store_true", default=False,
+        help="Skip uploading to the printer.",
+    )
+    printer.add_argument(
+        "--print-after-upload", action="store_true", default=False,
+        help="Start printing immediately after upload.",
+    )
+
+    # --- Config file ---
+    p.add_argument(
+        "--config", type=str, default=None, metavar="PATH",
+        help=(
+            "Path to a TOML config file. "
+            "Default lookup: ./filament-calibrator.toml, "
+            "then ~/.config/filament-calibrator/config.toml."
+        ),
+    )
+
+    # --- Output options ---
+    output = p.add_argument_group("output options")
+    output.add_argument(
+        "--output-dir", type=str, default=None,
+        help="Directory for output files. Default: temp directory.",
+    )
+    output.add_argument(
+        "--keep-files", action="store_true", default=False,
+        help="Keep intermediate files (STL, raw G-code).",
+    )
+    output.add_argument(
+        "--ascii-gcode", action="store_true", default=False,
+        help=(
+            "Output ASCII (.gcode) instead of binary (.bgcode). "
+            "Binary is the default; it supports thumbnail previews "
+            "on the printer LCD."
+        ),
+    )
+
+    # --- Verbosity ---
+    p.add_argument(
+        "-v", "--verbose", action="store_true", default=False,
+        help="Show detailed debug output.",
+    )
+
+    return p
+
+
+def run(args: argparse.Namespace) -> None:
+    """Execute the full shrinkage-test calibration pipeline.
+
+    1. Generate a cross STL.
+    2. Slice with standard settings.
+    3. Inject thumbnails and metadata.
+    4. Upload to the printer (unless ``--no-upload``).
+    """
+    # Load TOML config and apply defaults.
+    toml_config = load_config(args.config)
+    _apply_config(
+        args, toml_config,
+        explicit_keys=getattr(args, "_explicit_keys", None),
+    )
+
+    if args.verbose:
+        cfg_path = _find_config_path(args.config)
+        if cfg_path is not None:
+            print(f"[DEBUG] Config file: {cfg_path}")
+            print(f"[DEBUG] Config values: {toml_config}")
+        else:
+            print("[DEBUG] No config file loaded")
+
+    # Fail fast: validate upload requirements.
+    if not args.no_upload and (not args.printer_url or not args.api_key):
+        print("Error: --printer-url and --api-key are required for upload.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve filament preset for slicer settings.
+    resolved = gl.resolve_filament_preset(
+        args.filament_type,
+        nozzle_temp=args.nozzle_temp if args.nozzle_temp is not _UNSET else None,
+        bed_temp=args.bed_temp if args.bed_temp is not _UNSET else None,
+        fan_speed=args.fan_speed if args.fan_speed is not _UNSET else None,
+    )
+    nozzle_temp: int = resolved["nozzle_temp"]
+    bed_temp: int = resolved["bed_temp"]
+    fan_speed: int = resolved["fan_speed"]
+
+    # Resolve printer model for bed dimensions and metadata.
+    printer_name: Optional[str] = None
+    bed_shape: Optional[str] = None
+    if args.printer is not None:
+        try:
+            printer_name = gl.resolve_printer(args.printer)
+        except ValueError as exc:
+            sys.exit(f"error: {exc}")
+        if args.bed_center is None:
+            args.bed_center = gl.compute_bed_center(printer_name)
+        bed_shape = gl.compute_bed_shape(printer_name)
+
+    _validate_printer_temps(printer_name, nozzle_temp, bed_temp)
+
+    # Derive layer height and extrusion width from nozzle size.
+    nozzle_size: float = args.nozzle_size
+    layer_height: float = (
+        args.layer_height if args.layer_height is not _UNSET
+        else round(nozzle_size * 0.5, 2)
+    )
+    extrusion_width: float = (
+        args.extrusion_width if args.extrusion_width is not _UNSET
+        else round(nozzle_size * 1.125, 2)
+    )
+
+    if args.verbose:
+        filament_key = args.filament_type.upper()
+        preset = gl.FILAMENT_PRESETS.get(filament_key)
+        if preset is not None:
+            print(f"[DEBUG] Filament preset '{filament_key}' found")
+        else:
+            print(f"[DEBUG] Filament type '{filament_key}' not in presets, "
+                  "using fallback defaults")
+        print(f"[DEBUG] Resolved: nozzle_temp={nozzle_temp} bed_temp={bed_temp} "
+              f"fan_speed={fan_speed}")
+        print(f"[DEBUG] Nozzle: {nozzle_size} mm → "
+              f"layer_height={layer_height} extrusion_width={extrusion_width}")
+        if printer_name is not None:
+            print(f"[DEBUG] Printer: {printer_name} "
+                  f"(bed center: {args.bed_center})")
+
+    config = ShrinkageCrossConfig(
+        arm_length=args.arm_length,
+        filament_type=args.filament_type,
+    )
+    out_dir = _resolve_output_dir(args.output_dir, prefix="shrinkage-test-")
+
+    if args.verbose:
+        print(f"[DEBUG] Arm length: {config.arm_length} mm")
+        print(f"[DEBUG] Output directory: {out_dir}")
+
+    print(
+        f"Filament: {config.filament_type}  "
+        f"Nozzle: {nozzle_size} mm  "
+        f"Arm: {config.arm_length} mm  "
+        f"Temp: {nozzle_temp}°C  Bed: {bed_temp}°C  Fan: {fan_speed}%"
+    )
+
+    # --- Step 1: Generate STL ---
+    suffix = gl.unique_suffix()
+    safe_type = gl.safe_filename_part(config.filament_type)
+    stl_name = f"shrinkage_cross_{safe_type}_{suffix}.stl"
+    stl_path = str(out_dir / stl_name)
+    print(f"Generating model → {stl_path}")
+    generate_shrinkage_cross_stl(config, stl_path)
+
+    # --- Step 2: Slice with standard settings ---
+    gcode_ext = gl.gcode_ext(binary=not args.ascii_gcode)
+    raw_gcode_path = str(out_dir / stl_name.replace(".stl", f"_raw{gcode_ext}"))
+    print(f"Slicing → {raw_gcode_path}")
+    if args.verbose:
+        effective_center = args.bed_center or f"{DEFAULT_BED_CENTER} (default)"
+        print(f"[DEBUG] Bed center: {effective_center}")
+
+    result = slice_shrinkage_specimen(
+        stl_path=stl_path,
+        output_gcode_path=raw_gcode_path,
+        layer_height=layer_height,
+        extrusion_width=extrusion_width,
+        config_ini=args.config_ini,
+        prusaslicer_path=args.prusaslicer_path,
+        extra_args=args.extra_slicer_args,
+        nozzle_temp=nozzle_temp,
+        bed_temp=bed_temp,
+        fan_speed=fan_speed,
+        bed_center=args.bed_center,
+        bed_shape=bed_shape,
+        nozzle_diameter=nozzle_size,
+        printer_model=printer_name,
+        binary_gcode=not args.ascii_gcode,
+    )
+    if args.verbose:
+        print(f"[DEBUG] PrusaSlicer command: {' '.join(result.cmd)}")
+        if result.stdout.strip():
+            print(f"[DEBUG] PrusaSlicer stdout: {result.stdout.strip()}")
+
+    if not result.ok:
+        print(f"PrusaSlicer failed (exit {result.returncode}):", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    # --- Step 3: Inject thumbnails and metadata (no G-code insertion) ---
+    final_gcode_path = str(out_dir / stl_name.replace(".stl", gcode_ext))
+    print(f"Finalising → {final_gcode_path}")
+    gf = gl.load(raw_gcode_path)
+    gl.inject_thumbnails(gf, stl_path, DEFAULT_THUMBNAILS, verbose=args.verbose)
+    if printer_name is not None:
+        gl.patch_slicer_metadata(
+            gf, printer_name, nozzle_size, verbose=args.verbose
+        )
+    gf.lines = _patch_m862_nozzle_flags(
+        gf.lines,
+        nozzle_hardened=args.nozzle_hardened,
+        nozzle_high_flow=args.nozzle_high_flow,
+    )
+    gl.save(gf, final_gcode_path)
+
+    arm = config.arm_length
+    print(f"Expected dimensions: X={arm} Y={arm} Z={arm} mm")
+
+    # --- Clean up intermediate files ---
+    if not args.keep_files:
+        Path(stl_path).unlink(missing_ok=True)
+        Path(raw_gcode_path).unlink(missing_ok=True)
+
+    # --- Step 4: Upload ---
+    if not args.no_upload:
+        if args.verbose:
+            print(f"[DEBUG] Upload target: {args.printer_url}")
+            print(f"[DEBUG] Print after upload: {args.print_after_upload}")
+        print(f"Uploading to {args.printer_url}")
+        filename = gl.prusalink_upload(
+            base_url=args.printer_url,
+            api_key=args.api_key,
+            gcode_path=final_gcode_path,
+            print_after_upload=args.print_after_upload,
+        )
+        print(f"Uploaded as: {filename}")
+        if args.print_after_upload:
+            print("Print started.")
+    else:
+        print(f"G-code saved to: {final_gcode_path}")
+
+    print("Done.")
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Entry point: parse arguments and run the pipeline."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args._explicit_keys = _explicit_keys(parser, argv)
+    run(args)

--- a/src/filament_calibrator/shrinkage_model.py
+++ b/src/filament_calibrator/shrinkage_model.py
@@ -1,0 +1,213 @@
+"""Parametric 3-axis cross model for shrinkage calibration.
+
+Generates three perpendicular rectangular arms (X, Y, Z) meeting at a
+centre block, with square window cutouts at regular intervals and
+embossed axis labels.  The user prints the specimen, measures each arm
+with calipers, and calculates per-axis shrinkage.
+
+All dimensions are in millimetres.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import cadquery as cq
+
+# ---------------------------------------------------------------------------
+# Geometry constants
+# ---------------------------------------------------------------------------
+
+ARM_LENGTH = 100.0  # mm — default length of each arm
+ARM_SIZE = 10.0     # mm — cross-section of each arm (square)
+WINDOW_SIZE = 5.0   # mm — side length of square window cutouts
+WINDOW_INTERVAL = 20.0  # mm — spacing between window cutout centres
+LABEL_DEPTH = 0.6   # mm — embossed text depth
+LABEL_FONT_SIZE = 6.0  # mm — font size for axis labels
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShrinkageCrossConfig:
+    """Parameters for the shrinkage calibration cross.
+
+    Attributes
+    ----------
+    arm_length:     Length of each arm in mm.
+    arm_size:       Cross-section side length of each arm in mm.
+    filament_type:  Label for filament type (e.g. ``"ABS"``).
+    """
+
+    arm_length: float = ARM_LENGTH
+    arm_size: float = ARM_SIZE
+    filament_type: str = "PLA"
+
+
+# ---------------------------------------------------------------------------
+# Geometry builders
+# ---------------------------------------------------------------------------
+
+
+def _make_cross(config: ShrinkageCrossConfig) -> cq.Workplane:
+    """Build a 3-axis cross with window cutouts and axis labels.
+
+    The cross is composed of three perpendicular rectangular arms:
+
+    * **X arm** — lies along the X-axis.
+    * **Y arm** — lies along the Y-axis.
+    * **Z arm** — stands vertical.
+
+    All arms share the same square cross-section (*arm_size* × *arm_size*)
+    and meet at a centre block.  Square window cutouts are punched through
+    each arm at regular intervals, and ``X``/``Y``/``Z`` labels are
+    embossed near each arm's positive end.
+    """
+    length = config.arm_length
+    size = config.arm_size
+    half = size / 2.0
+
+    # --- Build the three arms -------------------------------------------
+    # X arm: centred on X-axis, lying flat at Y=[-half..+half], Z=[0..size]
+    x_arm = (
+        cq.Workplane("XY")
+        .box(length, size, size, centered=False)
+    )
+
+    # Y arm: centred on Y-axis, lying flat at X=[length/2 - half .. length/2 + half]
+    y_arm = (
+        cq.Workplane("XY")
+        .transformed(offset=(length / 2.0 - half, -(length / 2.0 - half), 0))
+        .box(size, length, size, centered=False)
+    )
+
+    # Z arm: vertical column
+    z_arm = (
+        cq.Workplane("XY")
+        .transformed(offset=(length / 2.0 - half, 0, 0))
+        .box(size, size, length, centered=False)
+    )
+
+    cross = x_arm.union(y_arm).union(z_arm)
+
+    # --- Window cutouts -------------------------------------------------
+    # Cut square through-holes at regular intervals along each arm.
+    # Skip positions that fall inside the centre intersection region.
+    centre_lo = length / 2.0 - half
+    centre_hi = length / 2.0 + half
+
+    win = WINDOW_SIZE
+    interval = WINDOW_INTERVAL
+
+    for pos in _window_positions(length, interval, centre_lo, centre_hi):
+        # X arm windows: cut through Y-axis (hole in YZ plane)
+        cross = cross.cut(
+            cq.Workplane("XZ")
+            .transformed(offset=(pos, 0, half))
+            .rect(win, win)
+            .extrude(size)
+        )
+
+    for pos in _window_positions(length, interval, centre_lo, centre_hi):
+        # Y arm windows: cut through X-axis (hole in XZ plane)
+        y_offset = -(length / 2.0 - half) + pos
+        cross = cross.cut(
+            cq.Workplane("YZ")
+            .transformed(offset=(0, y_offset, half))
+            .rect(win, win)
+            .extrude(size)
+        )
+
+    for pos in _window_positions(length, interval, centre_lo, centre_hi):
+        # Z arm windows: cut through Y-axis (hole in XY plane)
+        cross = cross.cut(
+            cq.Workplane("XY")
+            .transformed(offset=(length / 2.0, 0, pos))
+            .rect(win, win)
+            .extrude(size)
+        )
+
+    # --- Axis labels ----------------------------------------------------
+    font = LABEL_FONT_SIZE
+    depth = LABEL_DEPTH
+    label_offset = length - size  # near the positive end
+
+    # X label — on the top face of the X arm, near positive X end
+    x_label = (
+        cq.Workplane("XY")
+        .workplane(offset=size)
+        .center(label_offset, 0)
+        .text("X", font, depth, combine=False, halign="center", valign="center")
+    )
+    cross = cross.union(x_label)
+
+    # Y label — on the top face of the Y arm, near positive Y end
+    y_label = (
+        cq.Workplane("XY")
+        .workplane(offset=size)
+        .center(length / 2.0, length / 2.0 - half - size)
+        .text("Y", font, depth, combine=False, halign="center", valign="center")
+    )
+    cross = cross.union(y_label)
+
+    # Z label — on the front face of the Z arm, near the top
+    z_label = (
+        cq.Workplane("XZ")
+        .workplane(offset=0)
+        .center(length / 2.0, label_offset)
+        .text("Z", font, depth, combine=False, halign="center", valign="center")
+    )
+    cross = cross.union(z_label)
+
+    return cross
+
+
+def _window_positions(
+    arm_length: float,
+    interval: float,
+    centre_lo: float,
+    centre_hi: float,
+) -> list[float]:
+    """Return a list of centre positions for window cutouts along an arm.
+
+    Positions start at *interval* and repeat every *interval* up to
+    *arm_length*.  Positions that fall inside the centre intersection
+    region ``[centre_lo, centre_hi]`` are skipped.
+    """
+    positions: list[float] = []
+    pos = interval
+    while pos < arm_length:
+        if pos < centre_lo or pos > centre_hi:
+            positions.append(pos)
+        pos += interval
+    return positions
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def generate_shrinkage_cross_stl(
+    config: ShrinkageCrossConfig,
+    output_path: str,
+) -> str:
+    """One-shot: build the shrinkage cross and export to STL.
+
+    Parameters
+    ----------
+    config:      Cross configuration.
+    output_path: Where to write the ``.stl`` file.
+
+    Returns
+    -------
+    str
+        The *output_path* (for chaining convenience).
+    """
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    shape = _make_cross(config)
+    cq.exporters.export(shape, output_path, exportType="STL")
+    return output_path

--- a/src/filament_calibrator/slicer.py
+++ b/src/filament_calibrator/slicer.py
@@ -779,3 +779,117 @@ def slice_retraction_specimen(
         extra_args=cli_extra,
     )
     return gl.slice_model(exe, req)
+
+
+# ---------------------------------------------------------------------------
+# Shrinkage specimen — standard slicing for dimensional accuracy
+# ---------------------------------------------------------------------------
+
+SHRINKAGE_SLICER_ARGS: Dict[str, str] = {
+    "first-layer-height": "0.2",
+    "perimeters": "3",
+    "top-solid-layers": "5",
+    "bottom-solid-layers": "4",
+    "fill-density": "20%",
+    "skirts": "1",
+}
+"""Slicer defaults for shrinkage calibration cross.
+
+3 perimeters and 20% infill provide dimensional accuracy for measuring
+shrinkage.  5 top and 4 bottom solid layers ensure fully sealed surfaces.
+"""
+
+
+def slice_shrinkage_specimen(
+    stl_path: str,
+    output_gcode_path: str,
+    layer_height: float = 0.2,
+    extrusion_width: float = 0.45,
+    config_ini: Optional[str] = None,
+    prusaslicer_path: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
+    nozzle_temp: Optional[int] = None,
+    bed_temp: Optional[int] = None,
+    fan_speed: Optional[int] = None,
+    bed_center: Optional[str] = None,
+    bed_shape: Optional[str] = None,
+    nozzle_diameter: Optional[float] = None,
+    printer_model: Optional[str] = None,
+    binary_gcode: bool = True,
+) -> gl.RunResult:
+    """Slice a shrinkage calibration cross STL.
+
+    Uses standard slicing (not vase mode) with higher perimeter and infill
+    settings for dimensional accuracy.
+
+    When *config_ini* is ``None``, :data:`SHRINKAGE_SLICER_ARGS` are
+    applied together with the explicit *layer_height* and *extrusion_width*.
+
+    Parameters
+    ----------
+    stl_path:          Path to the input ``.stl`` file.
+    output_gcode_path: Desired output G-code path.
+    layer_height:      Layer height in mm (default 0.2).
+    extrusion_width:   Extrusion width in mm (default 0.45).
+    config_ini:        Optional PrusaSlicer ``.ini`` config file path.
+    prusaslicer_path:  Explicit path to PrusaSlicer executable.
+    extra_args:        Additional raw CLI arguments.
+    nozzle_temp:       Nozzle temperature in °C.
+    bed_temp:          Bed temperature in °C.
+    fan_speed:         Fan speed 0–100 %.
+    bed_center:        Bed centre as ``"X,Y"``.
+    bed_shape:         Bed shape as PrusaSlicer ``--bed-shape`` string.
+    nozzle_diameter:   Nozzle diameter in mm.
+    printer_model:     Printer model identifier.
+    binary_gcode:      Produce ``.bgcode`` output (default ``True``).
+
+    Returns
+    -------
+    gcode_lib.RunResult
+
+    Raises
+    ------
+    FileNotFoundError
+        If PrusaSlicer cannot be found.
+    """
+    exe = gl.find_prusaslicer_executable(explicit_path=prusaslicer_path)
+
+    cli_extra: List[str] = [
+        f"--center={bed_center or DEFAULT_BED_CENTER}",
+        f"--bed-shape={bed_shape or DEFAULT_BED_SHAPE}",
+        f"--thumbnails={DEFAULT_THUMBNAILS}",
+    ]
+    if binary_gcode:
+        cli_extra.append("--binary-gcode")
+
+    if config_ini is None:
+        for key, val in SHRINKAGE_SLICER_ARGS.items():
+            cli_extra.append(f"--{key}={val}")
+        cli_extra.append(f"--layer-height={layer_height}")
+        cli_extra.append(f"--extrusion-width={extrusion_width}")
+
+    if nozzle_diameter is not None:
+        cli_extra.append(f"--nozzle-diameter={nozzle_diameter}")
+    if nozzle_temp is not None:
+        cli_extra.append(f"--temperature={nozzle_temp}")
+        cli_extra.append(f"--first-layer-temperature={nozzle_temp}")
+    if bed_temp is not None:
+        cli_extra.append(f"--bed-temperature={bed_temp}")
+        cli_extra.append(f"--first-layer-bed-temperature={bed_temp}")
+    if fan_speed is not None:
+        cli_extra.append(f"--max-fan-speed={fan_speed}")
+        cli_extra.append(f"--min-fan-speed={fan_speed}")
+
+    if printer_model is not None:
+        cli_extra.append(f"--printer-model={printer_model}")
+
+    if extra_args:
+        cli_extra.extend(extra_args)
+
+    req = gl.SliceRequest(
+        input_path=stl_path,
+        output_path=output_gcode_path,
+        config_ini=config_ini,
+        extra_args=cli_extra,
+    )
+    return gl.slice_model(exe, req)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -28,6 +28,7 @@ from filament_calibrator.gui import (
     build_flow_namespace,
     build_pa_namespace,
     build_retraction_namespace,
+    build_shrinkage_namespace,
     build_temp_tower_namespace,
     find_output_file,
     get_preset,
@@ -1191,6 +1192,67 @@ class TestBuildRetractionNamespace:
             printer="MK4S",
             ascii_gcode=True,
             output_dir="/tmp/retraction",
+            config_ini="",
+            prusaslicer_path="",
+            printer_url="",
+            api_key="",
+            no_upload=True,
+            print_after_upload=False,
+        )
+        assert ns.config_ini is None
+        assert ns.prusaslicer_path is None
+        assert ns.printer_url is None
+        assert ns.api_key is None
+
+
+# ---------------------------------------------------------------------------
+# build_shrinkage_namespace
+# ---------------------------------------------------------------------------
+
+
+class TestBuildShrinkageNamespace:
+    """Test build_shrinkage_namespace()."""
+
+    def test_basic(self) -> None:
+        ns = build_shrinkage_namespace(
+            filament_type="PLA",
+            arm_length=100.0,
+            nozzle_temp=215,
+            bed_temp=60,
+            fan_speed=100,
+            nozzle_size=0.4,
+            layer_height=0.2,
+            extrusion_width=0.45,
+            printer="COREONE",
+            ascii_gcode=False,
+            output_dir="/tmp/shrinkage",
+            config_ini=None,
+            prusaslicer_path=None,
+            printer_url=None,
+            api_key=None,
+            no_upload=True,
+            print_after_upload=False,
+        )
+        assert ns.arm_length == 100.0
+        assert ns.nozzle_temp == 215
+        assert ns.layer_height == 0.2
+        assert ns.extrusion_width == 0.45
+        assert ns.verbose is True
+        assert ns.keep_files is True
+
+    def test_empty_strings_become_none(self) -> None:
+        ns = build_shrinkage_namespace(
+            filament_type="PETG",
+            arm_length=80.0,
+            nozzle_temp=240,
+            bed_temp=80,
+            fan_speed=50,
+            nozzle_size=0.6,
+            layer_height=0.3,
+            extrusion_width=0.68,
+            printer="MK4S",
+            ascii_gcode=True,
+            output_dir="/tmp/shrinkage",
             config_ini="",
             prusaslicer_path="",
             printer_url="",

--- a/tests/test_shrinkage_cli.py
+++ b/tests/test_shrinkage_cli.py
@@ -1,0 +1,610 @@
+"""Tests for filament_calibrator.shrinkage_cli — shrinkage calibration CLI orchestration."""
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import gcode_lib as gl
+
+from filament_calibrator.cli import _KNOWN_TYPES, _UNSET
+from filament_calibrator.shrinkage_cli import (
+    build_parser,
+    main,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_returns_parser(self):
+        p = build_parser()
+        assert isinstance(p, argparse.ArgumentParser)
+
+    def test_no_required_args(self):
+        """Unlike flow/PA CLIs, shrinkage has no required arguments."""
+        p = build_parser()
+        args = p.parse_args([])
+        assert args.filament_type == "PLA"
+
+    def test_defaults(self):
+        p = build_parser()
+        args = p.parse_args([])
+        assert args.filament_type == "PLA"
+        assert args.arm_length == 100.0
+        assert args.nozzle_size == 0.4
+        assert args.nozzle_high_flow is False
+        assert args.nozzle_hardened is False
+        assert args.layer_height is _UNSET
+        assert args.extrusion_width is _UNSET
+        assert args.bed_temp is _UNSET
+        assert args.fan_speed is _UNSET
+        assert args.nozzle_temp is _UNSET
+        assert args.config_ini is None
+        assert args.prusaslicer_path is None
+        assert args.bed_center is None
+        assert args.extra_slicer_args is None
+        assert args.printer == "COREONE"
+        assert args.printer_url is None
+        assert args.api_key is None
+        assert args.no_upload is False
+        assert args.print_after_upload is False
+        assert args.output_dir is None
+        assert args.keep_files is False
+        assert args.ascii_gcode is False
+        assert args.verbose is False
+        assert args.config is None
+
+    def test_all_options(self):
+        p = build_parser()
+        args = p.parse_args([
+            "--filament-type", "PETG",
+            "--arm-length", "80",
+            "--nozzle-size", "0.6",
+            "--layer-height", "0.3",
+            "--extrusion-width", "0.68",
+            "--bed-temp", "85",
+            "--fan-speed", "50",
+            "--nozzle-temp", "240",
+            "--config-ini", "/tmp/config.ini",
+            "--prusaslicer-path", "/usr/bin/prusa-slicer",
+            "--bed-center", "100,100",
+            "--printer", "MK4S",
+            "--printer-url", "http://192.168.1.50",
+            "--api-key", "secret",
+            "--no-upload",
+            "--print-after-upload",
+            "--config", "/tmp/config.toml",
+            "--output-dir", "/tmp/out",
+            "--keep-files",
+            "--ascii-gcode",
+            "-v",
+        ])
+        assert args.filament_type == "PETG"
+        assert args.arm_length == 80.0
+        assert args.nozzle_size == 0.6
+        assert args.layer_height == 0.3
+        assert args.extrusion_width == 0.68
+        assert args.bed_temp == 85
+        assert args.fan_speed == 50
+        assert args.nozzle_temp == 240
+        assert args.config_ini == "/tmp/config.ini"
+        assert args.prusaslicer_path == "/usr/bin/prusa-slicer"
+        assert args.bed_center == "100,100"
+        assert args.printer == "MK4S"
+        assert args.printer_url == "http://192.168.1.50"
+        assert args.api_key == "secret"
+        assert args.no_upload is True
+        assert args.print_after_upload is True
+        assert args.config == "/tmp/config.toml"
+        assert args.output_dir == "/tmp/out"
+        assert args.keep_files is True
+        assert args.ascii_gcode is True
+        assert args.verbose is True
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    @pytest.fixture(autouse=True)
+    def _fix_suffix(self):
+        with patch("gcode_lib.unique_suffix", return_value="abc12"):
+            yield
+
+    def _make_args(self, tmp_path, **overrides):
+        defaults = dict(
+            filament_type="PLA",
+            arm_length=100.0,
+            nozzle_size=0.4,
+            nozzle_high_flow=False, nozzle_hardened=False,
+            layer_height=_UNSET, extrusion_width=_UNSET,
+            bed_temp=_UNSET, fan_speed=_UNSET, nozzle_temp=_UNSET,
+            config_ini=None, prusaslicer_path=None,
+            extra_slicer_args=None, bed_center=None,
+            printer="COREONE",
+            printer_url=None, api_key=None,
+            no_upload=True, print_after_upload=False,
+            output_dir=str(tmp_path), keep_files=False,
+            ascii_gcode=False,
+            config=None, verbose=False,
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_full_pipeline_no_upload(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path)
+        run(args)
+
+        mock_gen.assert_called_once()
+        mock_slice.assert_called_once()
+        mock_load.assert_called_once()
+        mock_save.assert_called_once()
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_slicer_failure_exits(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(
+            ok=False, returncode=1, stderr="bad"
+        )
+
+        args = self._make_args(tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            run(args)
+        assert exc_info.value.code == 1
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.prusalink_upload")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_upload(
+        self, mock_gen, mock_slice, mock_load, mock_save, mock_upload,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+        mock_upload.return_value = "cross.gcode"
+
+        args = self._make_args(
+            tmp_path,
+            no_upload=False,
+            printer_url="http://192.168.1.100",
+            api_key="key123",
+            print_after_upload=True,
+        )
+        run(args)
+
+        mock_upload.assert_called_once()
+        call_kwargs = mock_upload.call_args[1]
+        assert call_kwargs["base_url"] == "http://192.168.1.100"
+        assert call_kwargs["api_key"] == "key123"
+        assert call_kwargs["print_after_upload"] is True
+
+    @patch("filament_calibrator.shrinkage_cli.load_config", return_value={})
+    def test_upload_missing_url_exits(self, mock_cfg, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            no_upload=False,
+            printer_url=None,
+            api_key=None,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            run(args)
+        assert exc_info.value.code == 1
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_keep_files(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        """Intermediate files preserved when --keep-files is set."""
+        stl = tmp_path / "shrinkage_cross_PLA_abc12.stl"
+        raw = tmp_path / "shrinkage_cross_PLA_abc12_raw.bgcode"
+        stl.touch()
+        raw.touch()
+        mock_gen.return_value = str(stl)
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, keep_files=True)
+        run(args)
+
+        assert stl.exists()
+        assert raw.exists()
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_no_keep_files_cleans_up(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        """Intermediate files removed by default."""
+        stl = tmp_path / "shrinkage_cross_PLA_abc12.stl"
+        raw = tmp_path / "shrinkage_cross_PLA_abc12_raw.bgcode"
+        stl.touch()
+        raw.touch()
+        mock_gen.return_value = str(stl)
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, keep_files=False)
+        run(args)
+
+        assert not stl.exists()
+        assert not raw.exists()
+
+    @patch("filament_calibrator.shrinkage_cli._find_config_path", return_value=None)
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_verbose_output(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, mock_find_cfg, tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True, cmd=["ps"], stdout="", stderr="")
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, verbose=True)
+        run(args)
+
+        out = capsys.readouterr().out
+        assert "[DEBUG]" in out
+        assert "No config file loaded" in out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_slicer_receives_correct_args(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, nozzle_size=0.6)
+        run(args)
+
+        call_kwargs = mock_slice.call_args[1]
+        assert call_kwargs["layer_height"] == 0.3  # 0.6 * 0.5
+        assert call_kwargs["extrusion_width"] == round(0.6 * 1.125, 2)
+        assert call_kwargs["nozzle_diameter"] == 0.6
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_prints_expected_dimensions(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path)
+        run(args)
+
+        out = capsys.readouterr().out
+        assert "Expected dimensions: X=100.0 Y=100.0 Z=100.0 mm" in out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_ascii_gcode(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, ascii_gcode=True)
+        run(args)
+
+        call_kwargs = mock_slice.call_args[1]
+        assert call_kwargs["binary_gcode"] is False
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_config_ini_forwarded(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, config_ini="/tmp/my.ini")
+        run(args)
+
+        call_kwargs = mock_slice.call_args[1]
+        assert call_kwargs["config_ini"] == "/tmp/my.ini"
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_custom_arm_length(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, arm_length=80.0)
+        run(args)
+
+        config_arg = mock_gen.call_args[0][0]
+        assert config_arg.arm_length == 80.0
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_verbose_unknown_filament(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path, capsys
+    ):
+        """Unknown filament type triggers fallback debug message."""
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True, cmd=["ps"], stdout="", stderr="")
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, filament_type="MYSTERY", verbose=True)
+        run(args)
+
+        out = capsys.readouterr().out
+        assert "not in presets" in out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_verbose_config_loaded(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path, capsys
+    ):
+        """Config file path is logged when verbose."""
+        config_file = tmp_path / "filament-calibrator.toml"
+        config_file.write_text("")
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True, cmd=["ps"], stdout="out", stderr="")
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(
+            tmp_path, verbose=True,
+            config=str(config_file),
+        )
+        run(args)
+
+        out = capsys.readouterr().out
+        assert "[DEBUG] Config file:" in out
+        assert "[DEBUG] PrusaSlicer stdout:" in out
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_printer_none(
+        self, mock_gen, mock_slice, mock_load, mock_save,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path
+    ):
+        """Pipeline works when printer is None (no metadata patching)."""
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True)
+        mock_load.return_value = MagicMock(lines=[])
+
+        args = self._make_args(tmp_path, printer=None)
+        run(args)
+
+        mock_resolve.assert_not_called()
+        mock_patch_meta.assert_not_called()
+
+    @patch("gcode_lib.patch_slicer_metadata")
+    @patch("gcode_lib.inject_thumbnails")
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="COREONE")
+    @patch("filament_calibrator.shrinkage_cli.gl.prusalink_upload")
+    @patch("filament_calibrator.shrinkage_cli.gl.save")
+    @patch("filament_calibrator.shrinkage_cli.gl.load")
+    @patch("filament_calibrator.shrinkage_cli.slice_shrinkage_specimen")
+    @patch("filament_calibrator.shrinkage_cli.generate_shrinkage_cross_stl")
+    def test_upload_verbose(
+        self, mock_gen, mock_slice, mock_load, mock_save, mock_upload,
+        mock_resolve, mock_center, mock_shape,
+        mock_inject, mock_patch_meta, tmp_path, capsys
+    ):
+        mock_gen.return_value = str(tmp_path / "cross.stl")
+        mock_slice.return_value = MagicMock(ok=True, cmd=["ps"], stdout="", stderr="")
+        mock_load.return_value = MagicMock(lines=[])
+        mock_upload.return_value = "cross.gcode"
+
+        args = self._make_args(
+            tmp_path,
+            no_upload=False,
+            printer_url="http://192.168.1.100",
+            api_key="key123",
+            verbose=True,
+        )
+        run(args)
+
+        out = capsys.readouterr().out
+        assert "[DEBUG] Upload target:" in out
+
+    @patch("gcode_lib.resolve_printer", side_effect=ValueError("Unknown printer 'NOPE'"))
+    def test_invalid_printer_exits(self, mock_resolve, tmp_path):
+        """resolve_printer raising ValueError triggers sys.exit."""
+        args = self._make_args(tmp_path, printer="NOPE")
+        with pytest.raises(SystemExit):
+            run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_nozzle_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, nozzle_temp=300)
+            with pytest.raises(SystemExit, match="nozzle temp.*exceeds"):
+                run(args)
+
+    @patch("gcode_lib.compute_bed_shape", return_value="0x0,250x0,250x220,0x220")
+    @patch("gcode_lib.compute_bed_center", return_value="125,110")
+    @patch("gcode_lib.resolve_printer", return_value="TEST")
+    def test_bed_temp_exceeds_printer_limit(
+        self, mock_resolve, mock_center, mock_shape, tmp_path,
+    ):
+        with patch.dict(gl.PRINTER_PRESETS, {
+            "TEST": {"max_nozzle_temp": 290, "max_bed_temp": 120},
+        }):
+            args = self._make_args(tmp_path, bed_temp=130)
+            with pytest.raises(SystemExit, match="bed temp.*exceeds"):
+                run(args)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    @patch("filament_calibrator.shrinkage_cli.run")
+    def test_parses_and_runs(self, mock_run):
+        main(["--no-upload"])
+        mock_run.assert_called_once()
+        ns = mock_run.call_args[0][0]
+        assert ns.filament_type == "PLA"
+        assert ns.no_upload is True
+
+    @patch("filament_calibrator.shrinkage_cli.run")
+    def test_verbose_flag(self, mock_run):
+        main(["--no-upload", "-v"])
+        ns = mock_run.call_args[0][0]
+        assert ns.verbose is True

--- a/tests/test_shrinkage_model.py
+++ b/tests/test_shrinkage_model.py
@@ -1,0 +1,281 @@
+"""Tests for filament_calibrator.shrinkage_model — shrinkage cross generation."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+from filament_calibrator.shrinkage_model import (
+    ARM_LENGTH,
+    ARM_SIZE,
+    LABEL_DEPTH,
+    LABEL_FONT_SIZE,
+    WINDOW_INTERVAL,
+    WINDOW_SIZE,
+    ShrinkageCrossConfig,
+    _make_cross,
+    _window_positions,
+    generate_shrinkage_cross_stl,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_defaults(self):
+        assert ARM_LENGTH == 100.0
+        assert ARM_SIZE == 10.0
+        assert WINDOW_SIZE == 5.0
+        assert WINDOW_INTERVAL == 20.0
+        assert LABEL_DEPTH == 0.6
+        assert LABEL_FONT_SIZE == 6.0
+
+
+# ---------------------------------------------------------------------------
+# ShrinkageCrossConfig
+# ---------------------------------------------------------------------------
+
+
+class TestShrinkageCrossConfig:
+    def test_defaults(self):
+        config = ShrinkageCrossConfig()
+        assert config.arm_length == ARM_LENGTH
+        assert config.arm_size == ARM_SIZE
+        assert config.filament_type == "PLA"
+
+    def test_custom_values(self):
+        config = ShrinkageCrossConfig(
+            arm_length=80.0, arm_size=8.0, filament_type="ABS",
+        )
+        assert config.arm_length == 80.0
+        assert config.arm_size == 8.0
+        assert config.filament_type == "ABS"
+
+
+# ---------------------------------------------------------------------------
+# _window_positions
+# ---------------------------------------------------------------------------
+
+
+class TestWindowPositions:
+    def test_default_geometry(self):
+        """Windows at 20mm intervals, skipping centre block."""
+        positions = _window_positions(100.0, 20.0, 45.0, 55.0)
+        assert positions == [20.0, 40.0, 60.0, 80.0]
+
+    def test_skips_centre(self):
+        """Position exactly inside centre is excluded."""
+        positions = _window_positions(100.0, 10.0, 45.0, 55.0)
+        # 10, 20, 30, 40 are before centre; 50 is inside; 60..90 after
+        assert 50.0 not in positions
+        assert 45.0 not in positions
+        assert 40.0 in positions
+        assert 60.0 in positions
+
+    def test_short_arm(self):
+        """Arm too short for any windows returns empty list."""
+        positions = _window_positions(15.0, 20.0, 2.5, 12.5)
+        assert positions == []
+
+    def test_no_centre_overlap(self):
+        """All positions outside centre when arm is long enough."""
+        positions = _window_positions(200.0, 20.0, 95.0, 105.0)
+        for p in positions:
+            assert p < 95.0 or p > 105.0
+
+
+# ---------------------------------------------------------------------------
+# _make_cross (mocked CadQuery)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeCross:
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_creates_three_arms(self, mock_cq):
+        """Three boxes are created for X, Y, and Z arms."""
+        config = ShrinkageCrossConfig()
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        _make_cross(config)
+
+        # Three box() calls for the three arms
+        box_calls = mock_wp.box.call_args_list
+        assert len(box_calls) == 3
+
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_x_arm_dimensions(self, mock_cq):
+        """X arm has correct dimensions."""
+        config = ShrinkageCrossConfig(arm_length=100.0, arm_size=10.0)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        _make_cross(config)
+
+        # First box call is the X arm
+        first_box = mock_wp.box.call_args_list[0]
+        assert first_box == call(100.0, 10.0, 10.0, centered=False)
+
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_window_cutouts(self, mock_cq):
+        """Window cutouts are created via cut()."""
+        config = ShrinkageCrossConfig()
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        _make_cross(config)
+
+        # cut() must be called (windows on X, Y, and Z arms)
+        assert mock_wp.cut.call_count > 0
+
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_axis_labels(self, mock_cq):
+        """X, Y, and Z text labels are created."""
+        config = ShrinkageCrossConfig()
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        _make_cross(config)
+
+        # Three text() calls for X, Y, Z labels
+        text_calls = mock_wp.text.call_args_list
+        assert len(text_calls) == 3
+        labels = {c[0][0] for c in text_calls}
+        assert labels == {"X", "Y", "Z"}
+
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_custom_arm_length(self, mock_cq):
+        """Custom arm length is propagated to box dimensions."""
+        config = ShrinkageCrossConfig(arm_length=80.0, arm_size=8.0)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        _make_cross(config)
+
+        first_box = mock_wp.box.call_args_list[0]
+        assert first_box == call(80.0, 8.0, 8.0, centered=False)
+
+
+# ---------------------------------------------------------------------------
+# generate_shrinkage_cross_stl
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateShrinkageCrossStl:
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_creates_output_dir(self, mock_cq, tmp_path):
+        """Parent directory is created if it doesn't exist."""
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        output = tmp_path / "nested" / "dir" / "cross.stl"
+        config = ShrinkageCrossConfig()
+        result = generate_shrinkage_cross_stl(config, str(output))
+
+        assert result == str(output)
+        assert output.parent.exists()
+        mock_cq.exporters.export.assert_called_once()
+
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_returns_output_path(self, mock_cq, tmp_path):
+        """Function returns the output path for chaining."""
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        output = str(tmp_path / "test.stl")
+        config = ShrinkageCrossConfig()
+        result = generate_shrinkage_cross_stl(config, output)
+
+        assert result == output
+
+    @patch("filament_calibrator.shrinkage_model.cq")
+    def test_exports_as_stl(self, mock_cq, tmp_path):
+        """Exports in STL format."""
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.transformed.return_value = mock_wp
+        mock_wp.union.return_value = mock_wp
+        mock_wp.cut.return_value = mock_wp
+        mock_wp.workplane.return_value = mock_wp
+        mock_wp.center.return_value = mock_wp
+        mock_wp.text.return_value = mock_wp
+        mock_wp.rect.return_value = mock_wp
+        mock_wp.extrude.return_value = mock_wp
+
+        output = str(tmp_path / "test.stl")
+        config = ShrinkageCrossConfig()
+        generate_shrinkage_cross_stl(config, output)
+
+        export_call = mock_cq.exporters.export.call_args
+        assert export_call[1]["exportType"] == "STL"
+        assert export_call[0][1] == output

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -15,12 +15,14 @@ from filament_calibrator.slicer import (
     PA_PATTERN_SLICER_ARGS,
     PA_SLICER_ARGS,
     RETRACTION_SLICER_ARGS,
+    SHRINKAGE_SLICER_ARGS,
     VASE_MODE_SLICER_ARGS,
     slice_em_specimen,
     slice_flow_specimen,
     slice_pa_pattern,
     slice_pa_specimen,
     slice_retraction_specimen,
+    slice_shrinkage_specimen,
     slice_tower,
 )
 
@@ -2098,6 +2100,230 @@ class TestSliceRetractionSpecimen:
 
         slice_retraction_specimen(
             "/tmp/t.stl", "/tmp/t.gcode",
+            config_ini="/config.ini",
+            extra_args=["--custom", "val"],
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--custom" in req.extra_args
+        assert "val" in req.extra_args
+
+
+# ---------------------------------------------------------------------------
+# SHRINKAGE_SLICER_ARGS
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# slice_shrinkage_specimen
+# ---------------------------------------------------------------------------
+
+
+class TestSliceShrinkageSpecimen:
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_with_config_ini(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="ok", stderr=""
+        )
+
+        result = slice_shrinkage_specimen(
+            stl_path="/tmp/shrinkage.stl",
+            output_gcode_path="/tmp/shrinkage.gcode",
+            config_ini="/path/to/config.ini",
+        )
+
+        assert result.ok
+        req = mock_slice.call_args[0][1]
+        assert req.config_ini == "/path/to/config.ini"
+        # With config_ini, default slicer args should NOT be added
+        for key in SHRINKAGE_SLICER_ARGS:
+            assert f"--{key}" not in " ".join(req.extra_args)
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_without_config_ini(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="ok", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            stl_path="/tmp/shrinkage.stl",
+            output_gcode_path="/tmp/shrinkage.gcode",
+        )
+
+        req = mock_slice.call_args[0][1]
+        # Default args should be applied
+        for key, val in SHRINKAGE_SLICER_ARGS.items():
+            assert f"--{key}={val}" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_no_spiral_vase(self, mock_find, mock_slice):
+        """--spiral-vase should NOT be in the CLI args."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen("/tmp/s.stl", "/tmp/s.gcode")
+
+        req = mock_slice.call_args[0][1]
+        assert "--spiral-vase" not in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_defaults_used_without_config_ini(self, mock_find, mock_slice):
+        """All SHRINKAGE_SLICER_ARGS present when no config_ini."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen("/tmp/s.stl", "/tmp/s.gcode")
+
+        req = mock_slice.call_args[0][1]
+        for key, val in SHRINKAGE_SLICER_ARGS.items():
+            assert f"--{key}={val}" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_layer_height_and_extrusion_width(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode",
+            layer_height=0.3, extrusion_width=0.68,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--layer-height=0.3" in req.extra_args
+        assert "--extrusion-width=0.68" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_temp_bed_fan(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode",
+            nozzle_temp=230, bed_temp=80, fan_speed=50,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--temperature=230" in req.extra_args
+        assert "--first-layer-temperature=230" in req.extra_args
+        assert "--bed-temperature=80" in req.extra_args
+        assert "--first-layer-bed-temperature=80" in req.extra_args
+        assert "--max-fan-speed=50" in req.extra_args
+        assert "--min-fan-speed=50" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_bed_center_default(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen("/tmp/s.stl", "/tmp/s.gcode")
+
+        req = mock_slice.call_args[0][1]
+        assert f"--center={DEFAULT_BED_CENTER}" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_bed_center_custom(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode", bed_center="90,90",
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--center=90,90" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_nozzle_diameter(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode", nozzle_diameter=0.6,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--nozzle-diameter=0.6" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_binary_gcode_default(self, mock_find, mock_slice):
+        """binary_gcode defaults to True."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen("/tmp/s.stl", "/tmp/s.gcode")
+
+        req = mock_slice.call_args[0][1]
+        assert "--binary-gcode" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_binary_gcode_false(self, mock_find, mock_slice):
+        """binary_gcode=False → no --binary-gcode."""
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode", binary_gcode=False,
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--binary-gcode" not in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_printer_model_passed(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode", printer_model="COREONE",
+        )
+
+        req = mock_slice.call_args[0][1]
+        assert "--printer-model=COREONE" in req.extra_args
+
+    @patch("filament_calibrator.slicer.gl.slice_model")
+    @patch("filament_calibrator.slicer.gl.find_prusaslicer_executable")
+    def test_extra_args(self, mock_find, mock_slice):
+        mock_find.return_value = "/usr/bin/prusa-slicer"
+        mock_slice.return_value = gl.RunResult(
+            cmd=[], returncode=0, stdout="", stderr=""
+        )
+
+        slice_shrinkage_specimen(
+            "/tmp/s.stl", "/tmp/s.gcode",
             config_ini="/config.ini",
             extra_args=["--custom", "val"],
         )


### PR DESCRIPTION
## Summary
- New `shrinkage-test` CLI tool for measuring per-axis shrinkage (X/Y/Z) by printing a 3-axis calibration cross
- CadQuery parametric model: three perpendicular 10×10mm arms (100mm default), window cutouts at 20mm intervals, embossed X/Y/Z labels
- Standard slicing (3 perimeters, 20% infill, 5 top / 4 bottom solid layers) for dimensional accuracy
- Shrinkage tab added to Streamlit GUI between Retraction Test and Results
- Full documentation at `docs/shrinkage.md`

## New files
- `src/filament_calibrator/shrinkage_model.py` — CadQuery parametric cross model
- `src/filament_calibrator/shrinkage_cli.py` — CLI pipeline (model → slice → thumbnails → metadata → upload)
- `tests/test_shrinkage_model.py` — 15 model tests
- `tests/test_shrinkage_cli.py` — 25 CLI tests
- `docs/shrinkage.md` — usage documentation

## Modified files
- `slicer.py` — `SHRINKAGE_SLICER_ARGS` + `slice_shrinkage_specimen()`
- `gui.py` — Shrinkage tab, `build_shrinkage_namespace()`
- `pyproject.toml` — `shrinkage-test` entry point
- `CLAUDE.md`, `README.md` — updated for six tools
- `tests/test_slicer.py`, `tests/test_gui.py` — new test classes

## Test plan
- [x] 873 tests pass, 100% statement coverage enforced
- [ ] `shrinkage-test --help` prints usage
- [ ] Generate and slice a cross: `shrinkage-test --no-upload --keep-files`
- [ ] Verify GUI Shrinkage tab appears between Retraction Test and Results

🤖 Generated with [Claude Code](https://claude.com/claude-code)