### PR TITLE
Populate shrinkage tab from .ini config in GUI

### DIFF
--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -702,6 +702,7 @@ def apply_ini_to_session(
         state["flow_nozzle_temp"] = nt
         state["pa_nozzle_temp"] = nt
         state["retraction_nozzle_temp"] = nt
+        state["shrinkage_nozzle_temp"] = nt
         # Derive a temp tower range centred on the INI temperature.
         state["tt_start_temp"] = nt + 15
         state["tt_end_temp"] = nt - 15
@@ -713,6 +714,7 @@ def apply_ini_to_session(
         state["flow_bed_temp"] = bt
         state["pa_bed_temp"] = bt
         state["retraction_bed_temp"] = bt
+        state["shrinkage_bed_temp"] = bt
 
     if "fan_speed" in ini_vals:
         fs = ini_vals["fan_speed"]
@@ -721,6 +723,7 @@ def apply_ini_to_session(
         state["flow_fan"] = fs
         state["pa_fan"] = fs
         state["retraction_fan"] = fs
+        state["shrinkage_fan"] = fs
 
     if "layer_height" in ini_vals:
         lh = ini_vals["layer_height"]
@@ -728,6 +731,7 @@ def apply_ini_to_session(
         state["flow_lh"] = lh
         state["pa_lh"] = lh
         state["retraction_lh"] = lh
+        state["shrinkage_lh"] = lh
 
     if "extrusion_width" in ini_vals:
         ew = ini_vals["extrusion_width"]
@@ -735,6 +739,7 @@ def apply_ini_to_session(
         state["flow_ew"] = ew
         state["pa_ew"] = ew
         state["retraction_ew"] = ew
+        state["shrinkage_ew"] = ew
 
     if sidebar and "nozzle_diameter" in ini_vals:
         snapped = snap_nozzle_size(ini_vals["nozzle_diameter"])

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -772,37 +772,42 @@ class TestApplyIniToSession:
         }
         apply_ini_to_session(state, ini_vals)
 
-        # Nozzle temp → EM + flow + PA + retraction tabs, temp tower range.
+        # Nozzle temp → EM + flow + PA + retraction + shrinkage tabs, temp tower range.
         assert state["em_nozzle_temp"] == 220
         assert state["flow_nozzle_temp"] == 220
         assert state["pa_nozzle_temp"] == 220
         assert state["retraction_nozzle_temp"] == 220
+        assert state["shrinkage_nozzle_temp"] == 220
         assert state["tt_start_temp"] == 235
         assert state["tt_end_temp"] == 205
 
-        # Bed temp → all five tabs.
+        # Bed temp → all six tabs.
         assert state["tt_bed_temp"] == 65
         assert state["em_bed_temp"] == 65
         assert state["flow_bed_temp"] == 65
         assert state["pa_bed_temp"] == 65
         assert state["retraction_bed_temp"] == 65
+        assert state["shrinkage_bed_temp"] == 65
 
-        # Fan speed → all five tabs.
+        # Fan speed → all six tabs.
         assert state["tt_fan"] == 80
         assert state["em_fan"] == 80
         assert state["flow_fan"] == 80
         assert state["pa_fan"] == 80
         assert state["retraction_fan"] == 80
+        assert state["shrinkage_fan"] == 80
 
-        # Layer height / extrusion width → EM + flow + PA + retraction.
+        # Layer height / extrusion width → EM + flow + PA + retraction + shrinkage.
         assert state["em_lh"] == 0.15
         assert state["flow_lh"] == 0.15
         assert state["pa_lh"] == 0.15
         assert state["retraction_lh"] == 0.15
+        assert state["shrinkage_lh"] == 0.15
         assert state["em_ew"] == 0.45
         assert state["flow_ew"] == 0.45
         assert state["pa_ew"] == 0.45
         assert state["retraction_ew"] == 0.45
+        assert state["shrinkage_ew"] == 0.45
 
         # Selectbox widget keys (written directly for Streamlit key= binding).
         assert state["sidebar_nozzle_size"] == 0.4
@@ -819,6 +824,7 @@ class TestApplyIniToSession:
         assert state["flow_nozzle_temp"] == 210
         assert state["pa_nozzle_temp"] == 210
         assert state["retraction_nozzle_temp"] == 210
+        assert state["shrinkage_nozzle_temp"] == 210
         assert state["tt_start_temp"] == 225
         assert state["tt_end_temp"] == 195
         assert "tt_bed_temp" not in state


### PR DESCRIPTION
## Summary
- Add missing `shrinkage_` widget keys to `apply_ini_to_session()` so loading a PrusaSlicer `.ini` config updates the Shrinkage tab's temperature, bed temp, fan speed, layer height, and extrusion width fields

## Test plan
- [x] 877 tests pass with 100% coverage
- [x] Updated `TestApplyIniToSession` assertions to verify all shrinkage keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)