### PR TITLE
Fix PyInstaller spec for 6.x 3-tuple TOC format

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -49,12 +49,25 @@ a = Analysis(
     noarchive=False,
 )
 
+# Normalize TOC entries to 3-tuples for PyInstaller 6.x compatibility.
+# collect_all() may return 2-tuples (src, dest) but COLLECT expects
+# 3-tuples (dest_name, src_name, typecode).
+def _to_3_tuples(entries, typecode):
+    result = []
+    for entry in entries:
+        if len(entry) == 3:
+            result.append(entry)
+        elif len(entry) == 2:
+            result.append((*entry, typecode))
+    return result
+
+
 # Collect data files and binaries for packages with native/static assets.
 for pkg in ("streamlit", "cadquery", "OCP", "gcode_lib"):
     try:
         datas, binaries, hiddenimports = collect_all(pkg)
-        a.datas += datas
-        a.binaries += binaries
+        a.datas += _to_3_tuples(datas, "DATA")
+        a.binaries += _to_3_tuples(binaries, "BINARY")
         a.hiddenimports += hiddenimports
     except Exception:
         pass  # Package may not be installed


### PR DESCRIPTION
## Summary
- Fixed `collect_all()` 2-tuple entries causing `ValueError` in PyInstaller 6.19's `COLLECT` step
- Added `_to_3_tuples()` normalization helper to ensure all datas/binaries entries include the typecode field

## Test plan
- [x] Fixes `ValueError: not enough values to unpack (expected 3, got 2)` from CI build
- [ ] PyInstaller build completes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)