### PR TITLE
Fix build workflow: replace deprecated macos-13 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             artifact: FilamentCalibrator-linux-x86_64
           - os: macos-latest
             artifact: FilamentCalibrator-macos-arm64
-          - os: macos-13
+          - os: macos-14
             artifact: FilamentCalibrator-macos-x86_64
           - os: windows-latest
             artifact: FilamentCalibrator-windows-x86_64


### PR DESCRIPTION
## Summary
- Replaced deprecated `macos-13` runner with `macos-14` in the PyInstaller build workflow

## Test plan
- [ ] Build workflow succeeds on all 4 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)