### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """Automated filament temperature tower calibration for Prusa 3D printers."""
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary
- Bumped version from 0.2.0 to 0.2.1 in `pyproject.toml` and `__init__.py`
- Needed because v0.2.0 release was created before the macos-13 runner fix

## After merge
```bash
gh release create v0.2.1 --title "v0.2.1" --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)