### PR TITLE
Add platform install guides, GUI user's guide, and PyInstaller fixes

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,10 +85,56 @@ source .venv/bin/activate
 pip install -e .
 ```
 
+## Raspberry Pi (Linux ARM64)
+
+The PyPI wheels for `cadquery-ocp` don't include Linux ARM64 builds, so
+`pip install` and `uv tool install` won't work on a Raspberry Pi. Use
+[Miniforge](https://github.com/conda-forge/miniforge) (conda-forge for ARM)
+instead — conda-forge builds OCP for `linux-aarch64`.
+
+**1. Install Miniforge:**
+
+```bash
+curl -L -O https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
+bash Miniforge3-Linux-aarch64.sh
+```
+
+Accept the defaults and say **yes** when asked to initialize conda in your
+shell, then restart your shell:
+
+```bash
+source ~/.bashrc
+```
+
+**2. Create an environment with CadQuery and install filament-calibrator:**
+
+```bash
+conda create -n filcal python=3.12 cadquery -c conda-forge
+conda activate filcal
+pip install "filament-calibrator[gui]"
+```
+
+Since CadQuery and OCP are already installed by conda, pip will skip those
+dependencies and install the rest (gcode-lib, streamlit, etc.).
+
+**3. Run:**
+
+```bash
+conda activate filcal
+temperature-tower --help
+filament-calibrator-gui
+```
+
+You need to `conda activate filcal` each time before using the tools.
+
+> **Note:** PrusaSlicer is also required on your PATH. ARM64 `.AppImage`
+> builds are available from
+> [prusa3d.com](https://www.prusa3d.com/page/prusaslicer_424/).
+
 ## Conda alternative
 
-If pip installation doesn't work for your platform, CadQuery can be installed
-via conda-forge:
+If pip installation doesn't work on other platforms, CadQuery can also be
+installed via conda-forge:
 
 ```bash
 conda create -n filament-cal python=3.12


### PR DESCRIPTION
## Summary
- Add **Raspberry Pi** installation instructions (Miniforge + conda-forge + ezdxf fix + Flatpak PrusaSlicer with symlink)
- Add **Windows 11** installation instructions (uv + PrusaSlicer + filament-calibrator)
- Add **comprehensive GUI user's guide** (`docs/gui.md`) with 8 Playwright-captured screenshots covering all tabs, sidebar, results workflow, and recommended calibration order
- Add **Documentation section** to README with links to installation guide, GUI guide, and configuration
- Fix **macOS Gatekeeper** instructions: use `xattr -cr` instead of right-click (PyInstaller onedir isn't an .app bundle)
- Fix **PyInstaller** spec: include `copy_metadata()` for streamlit/gcode-lib/filament-calibrator so `importlib.metadata` works in frozen bundles

## Test plan
- [ ] Verify Raspberry Pi instructions work end-to-end (Miniforge → conda → pip → run)
- [ ] Verify Windows 11 instructions work (uv → PrusaSlicer → install → run)
- [ ] Verify all screenshot images render in `docs/gui.md` on GitHub
- [ ] Verify README documentation links resolve correctly
- [ ] Create a release to test PyInstaller build with metadata fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)