### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.1"
+version = "0.2.2"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """Automated filament temperature tower calibration for Prusa 3D printers."""
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 in pyproject.toml and __init__.py for new release

## Changes since v0.2.1
- GUI user's guide with screenshots
- Windows 11 and Raspberry Pi installation instructions
- README documentation section with links
- macOS Gatekeeper fix (`xattr -cr`)
- PyInstaller `copy_metadata()` fix for streamlit

🤖 Generated with [Claude Code](https://claude.com/claude-code)