### PR TITLE
Add Linux ARM64 standalone build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: FilamentCalibrator-linux-x86_64
+          - os: ubuntu-24.04-arm
+            artifact: FilamentCalibrator-linux-arm64
           - os: macos-latest
             artifact: FilamentCalibrator-macos-arm64
-          - os: macos-14
-            artifact: FilamentCalibrator-macos-x86_64
           - os: windows-latest
             artifact: FilamentCalibrator-windows-x86_64
     runs-on: ${{ matrix.os }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ Download a pre-built binary for your platform from the
 Extract the archive and run the `FilamentCalibrator` executable — it opens the
 Streamlit GUI in your browser.
 
-Available for Linux (x86_64), macOS (ARM64 and Intel), and Windows (x86_64).
+Available for Linux (x86_64 and ARM64), macOS (ARM64), and Windows (x86_64).
 
 > **macOS note:** Downloaded binaries are quarantined by Gatekeeper. Remove
 > the quarantine attribute before running:


### PR DESCRIPTION
## Summary
- Add `ubuntu-24.04-arm` runner to build matrix for native Linux ARM64 builds (Raspberry Pi)
- Remove duplicate `macos-14` entry (identical to `macos-latest` — both ARM64)
- Update installation docs to list Linux ARM64 as an available platform

## Test plan
- [ ] Create a release to trigger the build workflow
- [ ] Verify `FilamentCalibrator-linux-arm64.tar.gz` is attached to the release
- [ ] Test on Raspberry Pi: extract and run `./FilamentCalibrator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)