### PR TITLE
Fix ARM64 build: use conda-forge for cadquery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,14 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             artifact: FilamentCalibrator-linux-x86_64
           - os: ubuntu-24.04-arm
             artifact: FilamentCalibrator-linux-arm64
+            use_conda: true
           - os: macos-latest
             artifact: FilamentCalibrator-macos-arm64
           - os: windows-latest
@@ -26,15 +28,42 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        if: ${{ !matrix.use_conda }}
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install dependencies (pip)
+        if: ${{ !matrix.use_conda }}
         run: |
           pip install -e ".[gui]"
           pip install pyinstaller
 
+      - name: Install Miniforge (ARM64)
+        if: ${{ matrix.use_conda }}
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          python-version: "3.12"
+          activate-environment: build
+          channels: conda-forge
+
+      - name: Install dependencies (conda + pip)
+        if: ${{ matrix.use_conda }}
+        shell: bash -el {0}
+        run: |
+          conda install -y cadquery
+          pip install "ezdxf>=1.0,<1.4"
+          pip install -e ".[gui]"
+          pip install pyinstaller
+
       - name: Build with PyInstaller
+        if: ${{ !matrix.use_conda }}
+        working-directory: pyinstaller
+        run: pyinstaller filament-calibrator.spec
+
+      - name: Build with PyInstaller (conda)
+        if: ${{ matrix.use_conda }}
+        shell: bash -el {0}
         working-directory: pyinstaller
         run: pyinstaller filament-calibrator.spec
 


### PR DESCRIPTION
## Summary
- ARM64 Linux runner (`ubuntu-24.04-arm`) fails because `cadquery-ocp` has no PyPI wheels for `linux-aarch64`
- Use `conda-incubator/setup-miniconda` with conda-forge to install cadquery on the ARM64 runner
- Add `ezdxf` version pin (same fix as Raspberry Pi install)
- Add `fail-fast: false` so other platforms still build if ARM64 fails
- Non-ARM runners continue using pip as before

## Test plan
- [ ] Merge and create v0.2.3 release to trigger build
- [ ] Verify all 4 platform builds succeed
- [ ] Test ARM64 binary on Raspberry Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)