### PR TITLE
Fix PyInstaller metadata for streamlit version lookup

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -74,9 +74,13 @@ for pkg in ("streamlit", "cadquery", "OCP", "gcode_lib"):
 
 # Include package metadata (.dist-info) for packages that use
 # importlib.metadata at runtime (e.g. streamlit reads its own version).
+# NOTE: copy_metadata() returns 2-tuples (source, dest_dir) that must be
+# added directly — do NOT run through _to_3_tuples, which would swap the
+# semantics (PyInstaller 6.x interprets 3-tuple as (name, path, typecode),
+# not (path, dest, typecode)).
 for pkg in ("streamlit", "filament-calibrator", "gcode-lib"):
     try:
-        a.datas += _to_3_tuples(copy_metadata(pkg), "DATA")
+        a.datas += copy_metadata(pkg)
     except Exception:
         pass
 

--- a/pyinstaller/gui_entry.py
+++ b/pyinstaller/gui_entry.py
@@ -10,6 +10,42 @@ import os
 import sys
 
 
+def _patch_frozen_metadata() -> None:
+    """Make importlib.metadata work in frozen PyInstaller environments.
+
+    PyInstaller bundles .dist-info directories inside _MEIPASS, but
+    importlib.metadata may not find them if the path isn't on the search
+    list.  We patch ``importlib.metadata.version()`` to fall back to
+    scanning _MEIPASS for ``<normalised>-*.dist-info/METADATA`` when the
+    standard lookup fails.
+    """
+    if not getattr(sys, "frozen", False):
+        return
+
+    import importlib.metadata as _meta
+    from pathlib import Path
+
+    bundle_dir = Path(sys._MEIPASS)  # type: ignore[attr-defined]
+    _orig_version = _meta.version
+
+    def _frozen_version(name: str) -> str:
+        try:
+            return _orig_version(name)
+        except _meta.PackageNotFoundError:
+            pass
+        # Normalise package name (PEP 503) and search _MEIPASS
+        normalised = name.lower().replace("-", "_")
+        for dist_info in bundle_dir.glob(f"{normalised}-*.dist-info"):
+            meta_file = dist_info / "METADATA"
+            if meta_file.is_file():
+                for line in meta_file.read_text().splitlines():
+                    if line.lower().startswith("version:"):
+                        return line.split(":", 1)[1].strip()
+        raise _meta.PackageNotFoundError(name)
+
+    _meta.version = _frozen_version  # type: ignore[assignment]
+
+
 def _patch_streamlit_paths() -> None:
     """Fix Streamlit's runtime path detection in frozen environments."""
     if getattr(sys, "frozen", False):
@@ -23,6 +59,7 @@ def _patch_streamlit_paths() -> None:
 def main() -> None:
     """Launch the Streamlit GUI."""
     multiprocessing.freeze_support()  # Required on Windows
+    _patch_frozen_metadata()
     _patch_streamlit_paths()
 
     from streamlit.web.bootstrap import run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.3"
+version = "0.2.4"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """Automated filament temperature tower calibration for Prusa 3D printers."""
 from __future__ import annotations
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"


### PR DESCRIPTION
## Summary
- Fix `copy_metadata()` results being mangled by `_to_3_tuples()` — the 2-tuples should be added directly to `a.datas`, not converted to 3-tuples which swaps the source/dest semantics in PyInstaller 6.x
- Add runtime fallback in `gui_entry.py` that scans `_MEIPASS` for `.dist-info/METADATA` files when `importlib.metadata.version()` fails
- Bump version to 0.2.4

## Test plan
- [ ] Merge and create v0.2.4 release
- [ ] Download macOS standalone build and run `./FilamentCalibrator`
- [ ] Verify Streamlit GUI launches without `PackageNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)