### PR TITLE
Fix spec: restore _to_3_tuples for copy_metadata

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -74,13 +74,11 @@ for pkg in ("streamlit", "cadquery", "OCP", "gcode_lib"):
 
 # Include package metadata (.dist-info) for packages that use
 # importlib.metadata at runtime (e.g. streamlit reads its own version).
-# NOTE: copy_metadata() returns 2-tuples (source, dest_dir) that must be
-# added directly — do NOT run through _to_3_tuples, which would swap the
-# semantics (PyInstaller 6.x interprets 3-tuple as (name, path, typecode),
-# not (path, dest, typecode)).
+# The runtime fallback in gui_entry.py handles the case where metadata
+# still isn't found (e.g. editable installs in CI).
 for pkg in ("streamlit", "filament-calibrator", "gcode-lib"):
     try:
-        a.datas += copy_metadata(pkg)
+        a.datas += _to_3_tuples(copy_metadata(pkg), "DATA")
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- Restores `_to_3_tuples()` for `copy_metadata()` results — PyInstaller 6.x TOC requires 3-tuples, raw 2-tuples crash at `_normalize_toc`
- The runtime fallback in `gui_entry.py` (from PR #35) handles the case where metadata still isn't found

## Test plan
- [ ] Merge, create v0.2.4 release, verify all builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)