### PR TITLE
Fix _to_3_tuples: data files placed at wrong paths in bundle

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -50,15 +50,20 @@ a = Analysis(
 )
 
 # Normalize TOC entries to 3-tuples for PyInstaller 6.x compatibility.
-# collect_all() may return 2-tuples (src, dest) but COLLECT expects
-# 3-tuples (dest_name, src_name, typecode).
+# collect_all() / copy_metadata() return 2-tuples (src_path, dest_dir).
+# COLLECT expects 3-tuples (dest_name, src_path, typecode) where
+# dest_name is the relative path inside the bundle.
+import os
+
 def _to_3_tuples(entries, typecode):
     result = []
     for entry in entries:
         if len(entry) == 3:
             result.append(entry)
         elif len(entry) == 2:
-            result.append((*entry, typecode))
+            src_path, dest_dir = entry
+            dest_name = os.path.join(dest_dir, os.path.basename(src_path))
+            result.append((dest_name, src_path, typecode))
     return result
 
 


### PR DESCRIPTION
## Summary
**Root cause found** for all PyInstaller issues (metadata not found, static files missing):

`_to_3_tuples` was converting `(src_path, dest_dir)` → `(src_path, dest_dir, "DATA")`, but PyInstaller's TOC format is `(dest_name, src_path, typecode)`. The source and destination were swapped, so **all** data files from `collect_all()` and `copy_metadata()` ended up at wrong paths in the bundle.

**Fix**: construct `dest_name` as `dest_dir/basename(src_path)`, then emit `(dest_name, src_path, typecode)`.

This should fix:
- ✅ Streamlit static files (HTML/CSS/JS frontend) placed correctly → no more dev server mode
- ✅ `.dist-info` metadata placed correctly → `importlib.metadata.version()` works natively
- ✅ CadQuery/OCP/gcode_lib data files placed correctly

## Test plan
- [ ] Merge, bump to v0.2.7, create release
- [ ] Download macOS build, verify GUI loads in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)