### PR TITLE
Fix _to_3_tuples: handle directory entries from copy_metadata

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -62,8 +62,16 @@ def _to_3_tuples(entries, typecode):
             result.append(entry)
         elif len(entry) == 2:
             src_path, dest_dir = entry
-            dest_name = os.path.join(dest_dir, os.path.basename(src_path))
-            result.append((dest_name, src_path, typecode))
+            if os.path.isdir(src_path):
+                # Walk directories (e.g. .dist-info from copy_metadata)
+                for root, _dirs, files in os.walk(src_path):
+                    for f in files:
+                        src_file = os.path.join(root, f)
+                        rel = os.path.relpath(src_file, os.path.dirname(src_path))
+                        result.append((rel, src_file, typecode))
+            else:
+                dest_name = os.path.join(dest_dir, os.path.basename(src_path))
+                result.append((dest_name, src_path, typecode))
     return result
 
 


### PR DESCRIPTION
## Summary
- `copy_metadata()` returns entries where `src_path` is a **directory** (`.dist-info/`), not a file
- The previous `_to_3_tuples` fix tried to add the directory as a single file entry, causing `ValueError: Resource ... is not a valid file!`
- Fix: when `src_path` is a directory, walk it and emit individual file entries

## Test plan
- [ ] Merge, delete v0.2.7 release, recreate
- [ ] Verify all 4 platform builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)