### PR TITLE
Bundle gui.py as data file for Streamlit

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -13,7 +13,12 @@ a = Analysis(
     ["gui_entry.py"],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[
+        # Streamlit needs the raw .py source to compile and execute.
+        # PyInstaller compiles modules to .pyc in the PYZ archive, so we
+        # must include gui.py as a data file for Streamlit to find it.
+        ("../src/filament_calibrator/gui.py", "filament_calibrator"),
+    ],
     hiddenimports=[
         # --- filament_calibrator package ---
         "filament_calibrator",


### PR DESCRIPTION
## Summary
- Streamlit reads and compiles the script `.py` source at runtime — it can't execute compiled `.pyc` from PyInstaller's PYZ archive
- Add `gui.py` as a data file in the spec so it's placed at `_MEIPASS/filament_calibrator/gui.py` where `gui_entry.py` expects it
- Fixes `FileNotFoundError: No such file or directory: '.../_internal/filament_calibrator/gui.py'`

## Test plan
- [ ] Build standalone binary via GitHub Actions
- [ ] Run binary, verify the GUI loads in the browser without `FileNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)