### PR TITLE
Add ~/filament-calibrator.toml to config lookup

### DIFF
--- a/src/filament_calibrator/config.py
+++ b/src/filament_calibrator/config.py
@@ -3,7 +3,8 @@
 Lookup order (first found wins):
 1. Explicit ``--config <path>`` CLI flag
 2. ``./filament-calibrator.toml`` (project-local)
-3. ``~/.config/filament-calibrator/config.toml`` (XDG user config)
+3. ``~/filament-calibrator.toml`` (home directory)
+4. ``~/.config/filament-calibrator/config.toml`` (XDG user config)
 """
 from __future__ import annotations
 
@@ -64,7 +65,8 @@ def _find_config_path(explicit: Optional[str] = None) -> Optional[Path]:
     Lookup order:
     1. *explicit* path (from ``--config``)
     2. ``./filament-calibrator.toml``
-    3. ``~/.config/filament-calibrator/config.toml``
+    3. ``~/filament-calibrator.toml``
+    4. ``~/.config/filament-calibrator/config.toml``
     """
     if explicit is not None:
         p = Path(explicit)
@@ -75,6 +77,10 @@ def _find_config_path(explicit: Optional[str] = None) -> Optional[Path]:
     local = Path("filament-calibrator.toml")
     if local.is_file():
         return local
+
+    home = Path.home() / "filament-calibrator.toml"
+    if home.is_file():
+        return home
 
     xdg = Path.home() / ".config" / "filament-calibrator" / "config.toml"
     if xdg.is_file():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,6 +104,16 @@ class TestFindConfigPath:
         result = _find_config_path()
         assert result.resolve() == local.resolve()
 
+    def test_home_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)  # no local file here
+        home_cfg = tmp_path / "filament-calibrator.toml"
+        home_cfg.write_text("")
+        with patch("filament_calibrator.config.Path.home", return_value=tmp_path):
+            # CWD has no config; home dir does
+            monkeypatch.chdir(tmp_path / "subdir")
+            (tmp_path / "subdir").mkdir()
+            assert _find_config_path() == home_cfg
+
     def test_xdg_file(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)  # no local file here
         xdg = tmp_path / ".config" / "filament-calibrator" / "config.toml"
@@ -111,6 +121,28 @@ class TestFindConfigPath:
         xdg.write_text("")
         with patch("filament_calibrator.config.Path.home", return_value=tmp_path):
             assert _find_config_path() == xdg
+
+    def test_local_takes_precedence_over_home(self, tmp_path, monkeypatch):
+        (tmp_path / "subdir").mkdir()
+        monkeypatch.chdir(tmp_path / "subdir")
+        local = tmp_path / "subdir" / "filament-calibrator.toml"
+        local.write_text("")
+        home_cfg = tmp_path / "filament-calibrator.toml"
+        home_cfg.write_text("")
+        with patch("filament_calibrator.config.Path.home", return_value=tmp_path):
+            result = _find_config_path()
+            assert result.resolve() == local.resolve()
+
+    def test_home_takes_precedence_over_xdg(self, tmp_path, monkeypatch):
+        (tmp_path / "subdir").mkdir()
+        monkeypatch.chdir(tmp_path / "subdir")
+        home_cfg = tmp_path / "filament-calibrator.toml"
+        home_cfg.write_text("")
+        xdg = tmp_path / ".config" / "filament-calibrator" / "config.toml"
+        xdg.parent.mkdir(parents=True)
+        xdg.write_text("")
+        with patch("filament_calibrator.config.Path.home", return_value=tmp_path):
+            assert _find_config_path() == home_cfg
 
     def test_local_takes_precedence_over_xdg(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- Add `~/filament-calibrator.toml` as a config lookup path between the CWD and XDG paths
- In the standalone PyInstaller build, CWD is the app bundle directory (e.g. `~/Downloads/FilamentCalibrator/`), so the existing `./filament-calibrator.toml` lookup doesn't find the config in the user's home directory
- New lookup order: `./filament-calibrator.toml` → `~/filament-calibrator.toml` → `~/.config/filament-calibrator/config.toml`

## Test plan
- [ ] CI tests pass (new tests for home dir lookup, precedence over XDG, local precedence over home)
- [ ] Place `filament-calibrator.toml` in home directory, run standalone build, verify config is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)