### PR TITLE
Stub casadi module to fix Windows DLL error

### DIFF
--- a/src/filament_calibrator/em_model.py
+++ b/src/filament_calibrator/em_model.py
@@ -16,10 +16,31 @@ from typing import Any
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq
 
         cq = _cq

--- a/src/filament_calibrator/flow_model.py
+++ b/src/filament_calibrator/flow_model.py
@@ -15,10 +15,31 @@ from typing import Any
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq
 
         cq = _cq

--- a/src/filament_calibrator/model.py
+++ b/src/filament_calibrator/model.py
@@ -17,10 +17,31 @@ from typing import Any
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq
 
         cq = _cq

--- a/src/filament_calibrator/pa_model.py
+++ b/src/filament_calibrator/pa_model.py
@@ -16,10 +16,31 @@ from typing import Any
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq
 
         cq = _cq

--- a/src/filament_calibrator/pa_pattern.py
+++ b/src/filament_calibrator/pa_pattern.py
@@ -20,10 +20,31 @@ from typing import Any, List, Optional, Tuple
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq  # type: ignore[import-untyped]
 
         cq = _cq

--- a/src/filament_calibrator/retraction_model.py
+++ b/src/filament_calibrator/retraction_model.py
@@ -20,10 +20,31 @@ from typing import Any
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq  # type: ignore[import-untyped]
 
         cq = _cq

--- a/src/filament_calibrator/shrinkage_model.py
+++ b/src/filament_calibrator/shrinkage_model.py
@@ -18,10 +18,31 @@ from typing import Any
 cq: Any = None  # populated by _ensure_cq()
 
 
+def _stub_casadi() -> None:
+    """Provide a stub ``casadi`` package when the real one is not yet loaded.
+
+    cadquery unconditionally imports casadi for its assembly constraint
+    solver, but this project uses only basic geometry operations and never
+    invokes the solver.  On Windows PyInstaller bundles the casadi native
+    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
+    stub lets cadquery import cleanly.
+    """
+    import sys
+
+    if "casadi" not in sys.modules:
+        import types
+
+        _fake = types.ModuleType("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
+        _stub_casadi()
         import cadquery as _cq
 
         cq = _cq

--- a/tests/test_em_model.py
+++ b/tests/test_em_model.py
@@ -9,9 +9,43 @@ from filament_calibrator.em_model import (
     CUBE_SIZE,
     EMCubeConfig,
     _ensure_cq,
+    _stub_casadi,
     _make_cube,
     generate_em_cube_stl,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flow_model.py
+++ b/tests/test_flow_model.py
@@ -15,11 +15,45 @@ from filament_calibrator.flow_model import (
     SPECIMEN_WIDTH,
     FlowSpecimenConfig,
     _ensure_cq,
+    _stub_casadi,
     generate_flow_specimen_stl,
     specimen_depth,
     total_height,
     _make_serpentine,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -44,6 +44,7 @@ from filament_calibrator.model import (
     TEXT_DEPTH,
     TowerConfig,
     _ensure_cq,
+    _stub_casadi,
     export_stl,
     generate_tower_stl,
     make_base,
@@ -52,6 +53,39 @@ from filament_calibrator.model import (
     tier_temperature,
     total_height,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pa_model.py
+++ b/tests/test_pa_model.py
@@ -14,10 +14,44 @@ from filament_calibrator.pa_model import (
     WALL_THICKNESS,
     PATowerConfig,
     _ensure_cq,
+    _stub_casadi,
     generate_pa_tower_stl,
     total_height,
     _make_hollow_tower,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pa_pattern.py
+++ b/tests/test_pa_pattern.py
@@ -22,6 +22,7 @@ from filament_calibrator.pa_pattern import (
     PAPatternConfig,
     _chevron_outline,
     _ensure_cq,
+    _stub_casadi,
     _make_chevron,
     _make_frame,
     _make_labels,
@@ -34,6 +35,39 @@ from filament_calibrator.pa_pattern import (
     tip_spacing,
     total_height,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retraction_model.py
+++ b/tests/test_retraction_model.py
@@ -16,12 +16,46 @@ from filament_calibrator.retraction_model import (
     TOWER_SPACING,
     RetractionTowerConfig,
     _ensure_cq,
+    _stub_casadi,
     _make_base,
     _make_retraction_towers,
     _make_tower,
     generate_retraction_tower_stl,
     total_height,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shrinkage_model.py
+++ b/tests/test_shrinkage_model.py
@@ -14,10 +14,44 @@ from filament_calibrator.shrinkage_model import (
     WINDOW_SIZE,
     ShrinkageCrossConfig,
     _ensure_cq,
+    _stub_casadi,
     _make_cross,
     _window_positions,
     generate_shrinkage_cross_stl,
 )
+
+
+# ---------------------------------------------------------------------------
+# _stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        import sys
+        import types
+
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            _stub_casadi()
+            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        import sys
+
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            _stub_casadi()
+            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `_stub_casadi()` to all 7 model files that injects a fake `casadi` module into `sys.modules` before importing cadquery
- cadquery unconditionally imports casadi for its constraint solver (`cadquery → assembly → solver → casadi → _casadi.pyd`), but this project only uses basic geometry — the solver is never invoked
- On Windows PyInstaller bundles, the `_casadi.pyd` native DLL is missing, causing `ImportError: DLL load failed while importing _casadi`
- The stub lets cadquery import cleanly without the native library

## Test plan
- [x] 902 tests pass with 100% coverage
- [ ] Verify Windows PyInstaller build no longer crashes on model generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)