### PR TITLE
Fix Windows casadi Opti attribute error in PyInstaller builds

### DIFF
--- a/src/filament_calibrator/em_model.py
+++ b/src/filament_calibrator/em_model.py
@@ -24,13 +24,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/src/filament_calibrator/flow_model.py
+++ b/src/filament_calibrator/flow_model.py
@@ -23,13 +23,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/src/filament_calibrator/model.py
+++ b/src/filament_calibrator/model.py
@@ -25,13 +25,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/src/filament_calibrator/pa_model.py
+++ b/src/filament_calibrator/pa_model.py
@@ -24,13 +24,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/src/filament_calibrator/pa_pattern.py
+++ b/src/filament_calibrator/pa_pattern.py
@@ -28,13 +28,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/src/filament_calibrator/retraction_model.py
+++ b/src/filament_calibrator/retraction_model.py
@@ -28,13 +28,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/src/filament_calibrator/shrinkage_model.py
+++ b/src/filament_calibrator/shrinkage_model.py
@@ -26,13 +26,23 @@ def _stub_casadi() -> None:
     invokes the solver.  On Windows PyInstaller bundles the casadi native
     DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
     stub lets cadquery import cleanly.
+
+    The stub uses a permissive ``__getattr__`` so that any attribute access
+    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
+    raising ``AttributeError``.
     """
     import sys
 
     if "casadi" not in sys.modules:
         import types
 
-        _fake = types.ModuleType("casadi")
+        class _CasadiStub(types.ModuleType):
+            """Module stub that returns itself for any attribute access."""
+
+            def __getattr__(self, name: str) -> _CasadiStub:
+                return self
+
+        _fake = _CasadiStub("casadi")
         _fake.__path__ = []  # type: ignore[attr-defined]
         sys.modules["casadi"] = _fake
         sys.modules["casadi.casadi"] = _fake

--- a/tests/test_em_model.py
+++ b/tests/test_em_model.py
@@ -29,8 +29,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)

--- a/tests/test_flow_model.py
+++ b/tests/test_flow_model.py
@@ -37,8 +37,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -69,8 +69,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)

--- a/tests/test_pa_model.py
+++ b/tests/test_pa_model.py
@@ -35,8 +35,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)

--- a/tests/test_pa_pattern.py
+++ b/tests/test_pa_pattern.py
@@ -51,8 +51,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)

--- a/tests/test_retraction_model.py
+++ b/tests/test_retraction_model.py
@@ -39,8 +39,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)

--- a/tests/test_shrinkage_model.py
+++ b/tests/test_shrinkage_model.py
@@ -35,8 +35,11 @@ class TestStubCasadi:
         saved_sub = sys.modules.pop("casadi.casadi", None)
         try:
             _stub_casadi()
-            assert isinstance(sys.modules["casadi"], types.ModuleType)
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, types.ModuleType)
             assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
+            # __getattr__ returns the stub itself for any attribute access
+            assert fake.Opti is fake
         finally:
             sys.modules.pop("casadi", None)
             sys.modules.pop("casadi.casadi", None)


### PR DESCRIPTION
## Summary
- Replace plain `types.ModuleType` casadi stub with `_CasadiStub` subclass that has a permissive `__getattr__` returning `self` for any attribute access
- Fixes `module 'casadi' has no attribute 'Opti'` error on Windows when cadquery's `solver.py` accesses `ca.Opti`, `ca.MX`, etc. at class definition time
- Updated all 7 model source files and 7 test files with full coverage

## Test plan
- [x] All 902 tests pass with 100% coverage
- [ ] CI passes
- [ ] Windows PyInstaller build tested — Generate button works without casadi errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)