### PR TITLE
Extract casadi stub to shared _cq_compat module

### DIFF
--- a/src/filament_calibrator/_cq_compat.py
+++ b/src/filament_calibrator/_cq_compat.py
@@ -1,0 +1,68 @@
+"""Compatibility helpers for importing cadquery in PyInstaller bundles.
+
+cadquery unconditionally imports ``casadi`` for its assembly constraint solver,
+but this project uses only basic geometry operations (Workplane, box, extrude)
+and never invokes the solver.  On Windows PyInstaller bundles the casadi native
+DLL (``_casadi.pyd``) is typically missing, causing an ``ImportError`` at import
+time.
+
+This module provides:
+
+* :func:`stub_casadi` — inject a lightweight stub ``casadi`` package into
+  ``sys.modules`` so that ``import cadquery`` succeeds without a real casadi.
+* :func:`ensure_cq` — lazy-import cadquery on first call (calling
+  :func:`stub_casadi` first) and cache the module in a global.
+
+All seven model modules import from here instead of duplicating the stub logic.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+# Cached cadquery module — populated by ensure_cq() on first call.
+_cq: Any = None
+
+
+class _CasadiStub(types.ModuleType):
+    """Module stub that returns itself for any non-dunder attribute access.
+
+    Dunder attributes (``__repr__``, ``__file__``, etc.) are delegated to the
+    normal ``ModuleType`` machinery so that ``repr(stub)`` and ``str(stub)``
+    work without triggering infinite recursion.
+    """
+
+    def __getattr__(self, name: str) -> _CasadiStub:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return self
+
+
+def stub_casadi() -> None:
+    """Inject a fake ``casadi`` package into ``sys.modules`` if absent.
+
+    The stub uses a permissive :meth:`__getattr__` so that any attribute
+    access (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead
+    of raising :exc:`AttributeError`.
+    """
+    if "casadi" not in sys.modules:
+        _fake = _CasadiStub("casadi")
+        _fake.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["casadi"] = _fake
+        sys.modules["casadi.casadi"] = _fake
+
+
+def ensure_cq() -> Any:
+    """Import cadquery on first use and return the cached module.
+
+    Calls :func:`stub_casadi` before the import so that the casadi
+    dependency is satisfied even when the native library is absent.
+    """
+    global _cq  # noqa: PLW0603
+    if _cq is None:
+        stub_casadi()
+        import cadquery as _cadquery
+
+        _cq = _cadquery
+    return _cq

--- a/src/filament_calibrator/em_model.py
+++ b/src/filament_calibrator/em_model.py
@@ -15,45 +15,17 @@ from typing import Any
 # the heavy OCCT/casadi native libraries at module-import time.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 # ---------------------------------------------------------------------------
 # Geometry constants

--- a/src/filament_calibrator/flow_model.py
+++ b/src/filament_calibrator/flow_model.py
@@ -14,45 +14,17 @@ from typing import Any
 # loading the heavy OCCT/casadi native libraries at module-import time.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 # ---------------------------------------------------------------------------
 # Geometry constants (defaults for the serpentine specimen)

--- a/src/filament_calibrator/model.py
+++ b/src/filament_calibrator/model.py
@@ -16,45 +16,17 @@ from typing import Any
 # without triggering the native dependency chain.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 
 # ---------------------------------------------------------------------------

--- a/src/filament_calibrator/pa_model.py
+++ b/src/filament_calibrator/pa_model.py
@@ -15,45 +15,17 @@ from typing import Any
 # the heavy OCCT/casadi native libraries at module-import time.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 # ---------------------------------------------------------------------------
 # Geometry constants (defaults for the PA tower)

--- a/src/filament_calibrator/pa_pattern.py
+++ b/src/filament_calibrator/pa_pattern.py
@@ -19,45 +19,17 @@ from typing import Any, List, Optional, Tuple
 # loading the heavy OCCT/casadi native libraries at module-import time.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq  # type: ignore[import-untyped]
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 # ---------------------------------------------------------------------------
 # Default constants (derived from Ellis PA tool)

--- a/src/filament_calibrator/retraction_model.py
+++ b/src/filament_calibrator/retraction_model.py
@@ -19,45 +19,17 @@ from typing import Any
 # loading the heavy OCCT/casadi native libraries at module-import time.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq  # type: ignore[import-untyped]
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 # ---------------------------------------------------------------------------
 # Geometry constants

--- a/src/filament_calibrator/shrinkage_model.py
+++ b/src/filament_calibrator/shrinkage_model.py
@@ -17,45 +17,17 @@ from typing import Any
 # loading the heavy OCCT/casadi native libraries at module-import time.
 cq: Any = None  # populated by _ensure_cq()
 
-
-def _stub_casadi() -> None:
-    """Provide a stub ``casadi`` package when the real one is not yet loaded.
-
-    cadquery unconditionally imports casadi for its assembly constraint
-    solver, but this project uses only basic geometry operations and never
-    invokes the solver.  On Windows PyInstaller bundles the casadi native
-    DLL (``_casadi.pyd``) is typically missing.  Injecting a lightweight
-    stub lets cadquery import cleanly.
-
-    The stub uses a permissive ``__getattr__`` so that any attribute access
-    (``ca.Opti``, ``ca.MX``, etc.) returns a harmless dummy instead of
-    raising ``AttributeError``.
-    """
-    import sys
-
-    if "casadi" not in sys.modules:
-        import types
-
-        class _CasadiStub(types.ModuleType):
-            """Module stub that returns itself for any attribute access."""
-
-            def __getattr__(self, name: str) -> _CasadiStub:
-                return self
-
-        _fake = _CasadiStub("casadi")
-        _fake.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["casadi"] = _fake
-        sys.modules["casadi.casadi"] = _fake
+# Stub/lazy-import helpers live in _cq_compat; thin wrappers here keep
+# existing call sites and test imports working.
+from filament_calibrator._cq_compat import ensure_cq as _ensure_cq_impl
+from filament_calibrator._cq_compat import stub_casadi as _stub_casadi
 
 
 def _ensure_cq() -> None:
     """Import cadquery on first use and cache in module globals."""
     global cq  # noqa: PLW0603
     if cq is None:
-        _stub_casadi()
-        import cadquery as _cq
-
-        cq = _cq
+        cq = _ensure_cq_impl()
 
 # ---------------------------------------------------------------------------
 # Geometry constants

--- a/tests/test_cq_compat.py
+++ b/tests/test_cq_compat.py
@@ -1,0 +1,121 @@
+"""Tests for filament_calibrator._cq_compat — casadi stub and lazy cadquery import."""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import filament_calibrator._cq_compat as mod
+
+from filament_calibrator._cq_compat import (
+    _CasadiStub,
+    ensure_cq,
+    stub_casadi,
+)
+
+
+# ---------------------------------------------------------------------------
+# _CasadiStub
+# ---------------------------------------------------------------------------
+
+
+class TestCasadiStub:
+    def test_returns_self_for_regular_attributes(self):
+        stub = _CasadiStub("casadi")
+        assert stub.Opti is stub
+        assert stub.MX is stub
+        assert stub.DM is stub
+
+    def test_chained_access_returns_self(self):
+        stub = _CasadiStub("casadi")
+        assert stub.Opti.solver.something is stub
+
+    def test_raises_attribute_error_for_dunder(self):
+        stub = _CasadiStub("casadi")
+        # Dunder names not provided by ModuleType should raise AttributeError
+        import pytest
+
+        with pytest.raises(AttributeError):
+            stub.__nonexistent_dunder__  # noqa: B018
+
+    def test_repr_does_not_recurse(self):
+        """repr() must not cause infinite recursion (was a bug before)."""
+        stub = _CasadiStub("casadi")
+        stub.__path__ = []  # type: ignore[attr-defined]
+        # Should not raise RecursionError
+        result = repr(stub)
+        assert isinstance(result, str)
+
+    def test_str_does_not_recurse(self):
+        stub = _CasadiStub("casadi")
+        stub.__path__ = []  # type: ignore[attr-defined]
+        result = str(stub)
+        assert isinstance(result, str)
+
+    def test_is_module_subclass(self):
+        stub = _CasadiStub("casadi")
+        assert isinstance(stub, types.ModuleType)
+
+
+# ---------------------------------------------------------------------------
+# stub_casadi
+# ---------------------------------------------------------------------------
+
+
+class TestStubCasadi:
+    def test_creates_stub_when_not_loaded(self):
+        saved = sys.modules.pop("casadi", None)
+        saved_sub = sys.modules.pop("casadi.casadi", None)
+        try:
+            stub_casadi()
+            fake = sys.modules["casadi"]
+            assert isinstance(fake, _CasadiStub)
+            assert isinstance(sys.modules["casadi.casadi"], _CasadiStub)
+            # Both entries point to the same stub instance
+            assert sys.modules["casadi.casadi"] is fake
+            # __getattr__ returns the stub itself for regular attributes
+            assert fake.Opti is fake
+            # __path__ is set so it looks like a package
+            assert fake.__path__ == []  # type: ignore[attr-defined]
+        finally:
+            sys.modules.pop("casadi", None)
+            sys.modules.pop("casadi.casadi", None)
+            if saved is not None:
+                sys.modules["casadi"] = saved
+            if saved_sub is not None:
+                sys.modules["casadi.casadi"] = saved_sub
+
+    def test_skips_when_already_loaded(self):
+        sentinel = MagicMock()
+        with patch.dict(sys.modules, {"casadi": sentinel}):
+            stub_casadi()
+            assert sys.modules["casadi"] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# ensure_cq
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCq:
+    def test_imports_cadquery_when_none(self):
+        saved = mod._cq
+        try:
+            mod._cq = None
+            mock_cq = MagicMock()
+            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+                result = ensure_cq()
+            assert result is mock_cq
+            assert mod._cq is mock_cq
+        finally:
+            mod._cq = saved
+
+    def test_returns_cached_on_subsequent_calls(self):
+        saved = mod._cq
+        try:
+            sentinel = MagicMock()
+            mod._cq = sentinel
+            result = ensure_cq()
+            assert result is sentinel
+        finally:
+            mod._cq = saved

--- a/tests/test_em_model.py
+++ b/tests/test_em_model.py
@@ -9,46 +9,9 @@ from filament_calibrator.em_model import (
     CUBE_SIZE,
     EMCubeConfig,
     _ensure_cq,
-    _stub_casadi,
     _make_cube,
     generate_em_cube_stl,
 )
-
-
-# ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +25,7 @@ class TestEnsureCq:
         try:
             mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert mod.cq is mock_cq
         finally:

--- a/tests/test_flow_model.py
+++ b/tests/test_flow_model.py
@@ -15,48 +15,11 @@ from filament_calibrator.flow_model import (
     SPECIMEN_WIDTH,
     FlowSpecimenConfig,
     _ensure_cq,
-    _stub_casadi,
     generate_flow_specimen_stl,
     specimen_depth,
     total_height,
     _make_serpentine,
 )
-
-
-# ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +33,7 @@ class TestEnsureCq:
         try:
             mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert mod.cq is mock_cq
         finally:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -44,7 +44,6 @@ from filament_calibrator.model import (
     TEXT_DEPTH,
     TowerConfig,
     _ensure_cq,
-    _stub_casadi,
     export_stl,
     generate_tower_stl,
     make_base,
@@ -53,42 +52,6 @@ from filament_calibrator.model import (
     tier_temperature,
     total_height,
 )
-
-
-# ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +66,7 @@ class TestEnsureCq:
         try:
             model_mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(model_mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert model_mod.cq is mock_cq
         finally:

--- a/tests/test_pa_model.py
+++ b/tests/test_pa_model.py
@@ -14,47 +14,10 @@ from filament_calibrator.pa_model import (
     WALL_THICKNESS,
     PATowerConfig,
     _ensure_cq,
-    _stub_casadi,
     generate_pa_tower_stl,
     total_height,
     _make_hollow_tower,
 )
-
-
-# ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +31,7 @@ class TestEnsureCq:
         try:
             mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert mod.cq is mock_cq
         finally:

--- a/tests/test_pa_pattern.py
+++ b/tests/test_pa_pattern.py
@@ -22,7 +22,6 @@ from filament_calibrator.pa_pattern import (
     PAPatternConfig,
     _chevron_outline,
     _ensure_cq,
-    _stub_casadi,
     _make_chevron,
     _make_frame,
     _make_labels,
@@ -38,42 +37,6 @@ from filament_calibrator.pa_pattern import (
 
 
 # ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
-
-
-# ---------------------------------------------------------------------------
 # _ensure_cq
 # ---------------------------------------------------------------------------
 
@@ -84,7 +47,7 @@ class TestEnsureCq:
         try:
             mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert mod.cq is mock_cq
         finally:

--- a/tests/test_retraction_model.py
+++ b/tests/test_retraction_model.py
@@ -16,49 +16,12 @@ from filament_calibrator.retraction_model import (
     TOWER_SPACING,
     RetractionTowerConfig,
     _ensure_cq,
-    _stub_casadi,
     _make_base,
     _make_retraction_towers,
     _make_tower,
     generate_retraction_tower_stl,
     total_height,
 )
-
-
-# ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +35,7 @@ class TestEnsureCq:
         try:
             mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert mod.cq is mock_cq
         finally:

--- a/tests/test_shrinkage_model.py
+++ b/tests/test_shrinkage_model.py
@@ -14,47 +14,10 @@ from filament_calibrator.shrinkage_model import (
     WINDOW_SIZE,
     ShrinkageCrossConfig,
     _ensure_cq,
-    _stub_casadi,
     _make_cross,
     _window_positions,
     generate_shrinkage_cross_stl,
 )
-
-
-# ---------------------------------------------------------------------------
-# _stub_casadi
-# ---------------------------------------------------------------------------
-
-
-class TestStubCasadi:
-    def test_creates_stub_when_not_loaded(self):
-        import sys
-        import types
-
-        saved = sys.modules.pop("casadi", None)
-        saved_sub = sys.modules.pop("casadi.casadi", None)
-        try:
-            _stub_casadi()
-            fake = sys.modules["casadi"]
-            assert isinstance(fake, types.ModuleType)
-            assert isinstance(sys.modules["casadi.casadi"], types.ModuleType)
-            # __getattr__ returns the stub itself for any attribute access
-            assert fake.Opti is fake
-        finally:
-            sys.modules.pop("casadi", None)
-            sys.modules.pop("casadi.casadi", None)
-            if saved is not None:
-                sys.modules["casadi"] = saved
-            if saved_sub is not None:
-                sys.modules["casadi.casadi"] = saved_sub
-
-    def test_skips_when_already_loaded(self):
-        import sys
-
-        sentinel = MagicMock()
-        with patch.dict(sys.modules, {"casadi": sentinel}):
-            _stub_casadi()
-            assert sys.modules["casadi"] is sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +31,7 @@ class TestEnsureCq:
         try:
             mod.cq = None
             mock_cq = MagicMock()
-            with patch.dict("sys.modules", {"cadquery": mock_cq}):
+            with patch.object(mod, "_ensure_cq_impl", return_value=mock_cq):
                 _ensure_cq()
             assert mod.cq is mock_cq
         finally:


### PR DESCRIPTION
## Summary
- Extract `_CasadiStub`, `stub_casadi()`, and `ensure_cq()` into a new shared `_cq_compat.py` module, eliminating 7x code duplication (~270 net lines removed)
- Fix latent `RecursionError` bug: `repr(stub)` / `str(stub)` caused infinite recursion because `ModuleType.__repr__` accesses `__file__` → triggers `__getattr__` → returns `self` → loop. Fixed by raising `AttributeError` for dunder names
- Consolidate 14 duplicated `TestStubCasadi` tests into one `test_cq_compat.py` with comprehensive coverage (including repr/str/chained access/dunder tests)
- Fix `# type: ignore[import-untyped]` drift between model files

## Test plan
- [x] All 898 tests pass with 100% coverage
- [ ] CI passes
- [ ] Windows PyInstaller build tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)