### PR TITLE
Bump version to 0.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.10"
+version = "0.2.11"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """Automated filament temperature tower calibration for Prusa 3D printers."""
 from __future__ import annotations
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"


### PR DESCRIPTION
## Summary
- Bump version from 0.2.10 to 0.2.11 in `pyproject.toml` and `__init__.py`
- PyPI rejected the v0.2.10 re-upload (versions are immutable once published)

## Test plan
- [ ] CI passes
- [ ] Release build triggers and publishes to PyPI successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)