### PR TITLE
Add back-links to README from docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Configuration
 
 ## Filament Presets

--- a/docs/extrusion-multiplier.md
+++ b/docs/extrusion-multiplier.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Extrusion Multiplier
 
 ![Extrusion Multiplier](images/extrusion-multiplier.png)

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # GUI
 
 ![Filament Calibrator GUI](images/gui/gui-overview.png)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Installation
 
 ## Prerequisites

--- a/docs/pressure-advance.md
+++ b/docs/pressure-advance.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Pressure Advance
 
 Two methods for finding the optimal PA/Linear Advance value: **tower**

--- a/docs/retraction-test.md
+++ b/docs/retraction-test.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Retraction Test
 
 ![Retraction Test](images/retraction-test.png)

--- a/docs/shrinkage.md
+++ b/docs/shrinkage.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Shrinkage Test
 
 Generates a parametric 3-axis calibration cross, slices it with standard

--- a/docs/temperature-tower.md
+++ b/docs/temperature-tower.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Temperature Tower
 
 ![Temperature Tower](images/temperature-tower.png)

--- a/docs/volumetric-flow.md
+++ b/docs/volumetric-flow.md
@@ -1,3 +1,5 @@
+[← Back to README](../README.md)
+
 # Volumetric Flow
 
 ![Volumetric Flow](images/volumetric-flow.png)


### PR DESCRIPTION
## Summary
- Add `← Back to README` link at the top of all 9 docs subdocuments so users can navigate back to the main README

## Files changed
`docs/installation.md`, `docs/temperature-tower.md`, `docs/extrusion-multiplier.md`, `docs/volumetric-flow.md`, `docs/pressure-advance.md`, `docs/retraction-test.md`, `docs/shrinkage.md`, `docs/configuration.md`, `docs/gui.md`

## Test plan
- [ ] Verify each doc page renders the back-link correctly on GitHub
- [ ] Verify links resolve to the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)