### PR TITLE
Bump to v0.2.14, require gcode-lib >= 1.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.12"
+version = "0.2.14"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"
@@ -32,7 +32,7 @@ classifiers = [
 
 dependencies = [
     "cadquery>=2.4",
-    "gcode-lib>=1.1.5",
+    "gcode-lib>=1.1.6",
     "tomli>=2.0; python_version < '3.11'",
 ]
 

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """Automated filament temperature tower calibration for Prusa 3D printers."""
 from __future__ import annotations
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.14 (also fixes pyproject.toml which was missed in the 0.2.13 bump)
- Require gcode-lib >= 1.1.6 to pick up the bgcode thumbnail params field order fix, which resolves "Invalid thumbnail" errors in Prusa GCode Viewer for patched bgcode files

## Test plan

- [x] All 929 filament-calibrator tests pass
- [ ] Generate a patched bgcode and open in Prusa GCode Viewer — thumbnails render without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)