### PR TITLE
Fix missing retraction_speed args in Results tab

### DIFF
--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -3198,6 +3198,8 @@ def _app() -> None:  # pragma: no cover
             set_em=set_em, extrusion_multiplier=float(res_em),
             set_retraction=set_retraction,
             retraction_length=float(res_retraction),
+            set_retraction_speed=set_retraction_speed,
+            retraction_speed=float(res_retraction_speed),
             set_shrinkage=set_shrinkage,
             xy_shrinkage=float(res_xy_shrinkage),
             z_shrinkage=float(res_z_shrinkage),


### PR DESCRIPTION
## Summary
- Fixes `TypeError: build_calibration_results() missing 2 required keyword-only arguments` when opening the Results tab in the GUI
- The `set_retraction_speed` and `retraction_speed` args were passed to `results_to_dict()` but missed in the `build_calibration_results()` call just above it

## Test plan
- [x] `pytest tests/` — 1295 passed, 100% coverage
- [ ] Open GUI, navigate to Results tab without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)