### PR TITLE
Fix duplicate Streamlit download_button element IDs

### DIFF
--- a/src/filament_calibrator/gui.py
+++ b/src/filament_calibrator/gui.py
@@ -3253,6 +3253,7 @@ def _app() -> None:  # pragma: no cover
                 data=merged.encode("utf-8"),
                 file_name=ini_name,
                 mime="text/plain",
+                key="download_calibrated_ini",
             )
         elif has_any and not config_ini_path:
             st.info(
@@ -3285,6 +3286,7 @@ def _show_results(
                 data=fh.read(),
                 file_name=gcode_path.name,
                 mime="application/octet-stream",
+                key="download_gcode",
             )
 
     # Thumbnail preview (use most recent STL for shared output dirs).


### PR DESCRIPTION
## Summary
- Adds unique `key` params to both `st.download_button` calls (calibrated INI and G-code) to fix `StreamlitDuplicateElementId` error when both buttons render on the Results tab

## Test plan
- [x] `pytest tests/` — 1295 passed, 100% coverage
- [ ] Open GUI Results tab without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)