### PR TITLE
Fix overhang test surfaces detaching from wall

### DIFF
--- a/src/filament_calibrator/overhang_model.py
+++ b/src/filament_calibrator/overhang_model.py
@@ -162,8 +162,8 @@ def _make_overhang_surface(
 
     The surface is a rectangular slab rotated around the X axis so that it
     protrudes from the wall face at the specified overhang angle from
-    vertical.  The rotation pivot is at the top of the wall where the
-    surface meets it.
+    vertical.  The rotation pivot is inside the wall so that the slab
+    overlaps the wall and produces a proper boolean union.
 
     At ``angle_deg=0`` the surface is vertical (flush with wall); at
     ``angle_deg=90`` it would be fully horizontal.
@@ -172,15 +172,23 @@ def _make_overhang_surface(
     wall_y_front = -(td / 2.0) + config.wall_thickness
     pivot_z = config.base_height + config.wall_height
 
-    # Build the surface slab lying flat (along +Y, thickness in Z)
+    # Extend the slab origin into the wall so the union is solid.
+    # Without this, the slab would only touch the wall at a single edge
+    # and CadQuery's boolean union would not create a connected solid.
+    overlap = config.wall_thickness / 2.0
+
+    # Build the surface slab lying flat (along +Y, thickness in Z),
+    # then shift it back by *overlap* so the near edge sits inside the
+    # wall before rotation.
     slab = (
         cq.Workplane("XY")
         .box(
             config.surface_width,
-            config.surface_length,
+            config.surface_length + overlap,
             config.surface_thickness,
             centered=(True, False, False),
         )
+        .translate((0, -overlap, 0))
     )
 
     # Rotation angle: overhang_angle is from vertical, so the rotation

--- a/tests/test_overhang_model.py
+++ b/tests/test_overhang_model.py
@@ -215,14 +215,16 @@ class TestMakeOverhangSurface:
 
         _make_overhang_surface(config, 45, 0.0)
 
+        overlap = config.wall_thickness / 2.0
         mock_wp.box.assert_called_once_with(
             config.surface_width,
-            config.surface_length,
+            config.surface_length + overlap,
             config.surface_thickness,
             centered=(True, False, False),
         )
         mock_wp.rotate.assert_called_once()
-        mock_wp.translate.assert_called_once()
+        # Two translates: one to shift slab into wall, one for final position
+        assert mock_wp.translate.call_count == 2
 
     @patch("filament_calibrator.overhang_model.cq")
     def test_rotation_angle(self, mock_cq):
@@ -242,6 +244,11 @@ class TestMakeOverhangSurface:
         assert rot_call[0][0] == (0, 0, 0)
         assert rot_call[0][1] == (1, 0, 0)
         assert rot_call[0][2] == -60.0
+
+        # First translate shifts slab into wall, second positions at wall
+        assert mock_wp.translate.call_count == 2
+        overlap_translate = mock_wp.translate.call_args_list[0]
+        assert overlap_translate[0][0] == (0, -config.wall_thickness / 2.0, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Each angled overhang slab only touched the wall at a single edge — CadQuery's boolean union requires volumetric overlap to create a connected solid
- Now the slab extends into the wall by half the wall thickness before rotation, ensuring the union is solid

## Test plan
- [x] `pytest tests/` — 1296 passed, 100% coverage
- [ ] Generate overhang STL and verify in PrusaSlicer that surfaces are attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)