### PR TITLE
Cap overhang slab length to prevent tips below base

### DIFF
--- a/src/filament_calibrator/overhang_model.py
+++ b/src/filament_calibrator/overhang_model.py
@@ -172,6 +172,17 @@ def _make_overhang_surface(
     wall_y_front = -(td / 2.0) + config.wall_thickness
     pivot_z = config.base_height + config.wall_height
 
+    # Cap surface length so the tip doesn't descend below the base plate.
+    # After rotation, the tip Z = pivot_z - length * cos(angle).
+    # We need tip Z >= base_height, so length <= wall_height / cos(angle).
+    angle_rad = math.radians(angle_deg)
+    cos_a = math.cos(angle_rad)
+    if cos_a > 1e-9:
+        max_length = config.wall_height / cos_a
+    else:
+        max_length = config.surface_length
+    effective_length = min(config.surface_length, max_length)
+
     # Extend the slab origin into the wall so the union is solid.
     # Without this, the slab would only touch the wall at a single edge
     # and CadQuery's boolean union would not create a connected solid.
@@ -184,7 +195,7 @@ def _make_overhang_surface(
         cq.Workplane("XY")
         .box(
             config.surface_width,
-            config.surface_length + overlap,
+            effective_length + overlap,
             config.surface_thickness,
             centered=(True, False, False),
         )

--- a/tests/test_overhang_model.py
+++ b/tests/test_overhang_model.py
@@ -1,6 +1,7 @@
 """Tests for filament_calibrator.overhang_model -- overhang test generation."""
 from __future__ import annotations
 
+import math
 from unittest.mock import MagicMock, call, patch
 
 import filament_calibrator.overhang_model as mod
@@ -249,6 +250,61 @@ class TestMakeOverhangSurface:
         assert mock_wp.translate.call_count == 2
         overlap_translate = mock_wp.translate.call_args_list[0]
         assert overlap_translate[0][0] == (0, -config.wall_thickness / 2.0, 0)
+
+    @patch("filament_calibrator.overhang_model.cq")
+    def test_length_capped_for_steep_angles(self, mock_cq):
+        """Steep angles get shorter slabs so they don't go below the base."""
+        config = OverhangTestConfig(wall_height=20.0, surface_length=25.0)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.rotate.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+
+        # angle=20: max_length = 20/cos(20°) ≈ 21.28 < 25
+        _make_overhang_surface(config, 20, 0.0)
+        box_call = mock_wp.box.call_args
+        overlap = config.wall_thickness / 2.0
+        slab_y = box_call[0][1]
+        effective = slab_y - overlap
+        assert effective < config.surface_length
+        # Tip should be at or above base_height
+        tip_z = config.wall_height - effective * math.cos(math.radians(20))
+        assert tip_z >= -0.01  # allow tiny float tolerance
+
+    @patch("filament_calibrator.overhang_model.cq")
+    def test_length_at_90_degrees(self, mock_cq):
+        """At 90° (horizontal), cos is ~0; full surface_length is used."""
+        config = OverhangTestConfig()
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.rotate.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+
+        _make_overhang_surface(config, 90, 0.0)
+        box_call = mock_wp.box.call_args
+        overlap = config.wall_thickness / 2.0
+        assert box_call[0][1] == config.surface_length + overlap
+
+    @patch("filament_calibrator.overhang_model.cq")
+    def test_length_not_capped_for_shallow_angles(self, mock_cq):
+        """Shallow angles keep full surface_length."""
+        config = OverhangTestConfig(wall_height=20.0, surface_length=25.0)
+
+        mock_wp = MagicMock()
+        mock_cq.Workplane.return_value = mock_wp
+        mock_wp.box.return_value = mock_wp
+        mock_wp.rotate.return_value = mock_wp
+        mock_wp.translate.return_value = mock_wp
+
+        # angle=70: max_length = 20/cos(70°) ≈ 58.5 > 25
+        _make_overhang_surface(config, 70, 0.0)
+        box_call = mock_wp.box.call_args
+        overlap = config.wall_thickness / 2.0
+        assert box_call[0][1] == config.surface_length + overlap
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- For steep angles (20–35°), the slab tip descended below Z=0, lifting the model off the bed
- Now each slab's effective length is capped at `wall_height / cos(angle)` so the tip stays at or above the base plate
- Example: at 20° with wall_height=20mm, the slab was 25mm long (tip at Z=-2.5mm); now capped to 21.3mm (tip at Z=1mm)

## Test plan
- [x] `pytest tests/` — 1299 passed, 100% coverage
- [ ] Generate overhang STL and verify no geometry below the base in PrusaSlicer

🤖 Generated with [Claude Code](https://claude.com/claude-code)