### PR TITLE
Fix overhang slab overlap direction (-Z instead of -Y)

### DIFF
--- a/src/filament_calibrator/overhang_model.py
+++ b/src/filament_calibrator/overhang_model.py
@@ -183,23 +183,27 @@ def _make_overhang_surface(
         max_length = config.surface_length
     effective_length = min(config.surface_length, max_length)
 
-    # Extend the slab origin into the wall so the union is solid.
-    # Without this, the slab would only touch the wall at a single edge
-    # and CadQuery's boolean union would not create a connected solid.
+    # Extend the slab downward (-Z) so that after rotation the extra
+    # material ends up *inside* the wall volume, creating a proper
+    # volumetric overlap for CadQuery's boolean union.
+    #
+    # Why -Z and not -Y?  The slab is rotated around the X axis by
+    # -(90 - angle_deg).  Under that rotation a point at (0, 0, -d)
+    # maps to y_rot = d·sin(θ) < 0 (into the wall) and
+    # z_rot = -d·cos(θ) < 0 (below the pivot), which is inside the
+    # wall for all angles 0 < angle < 90.  A -Y shift, by contrast,
+    # would rotate *above* the pivot and miss the wall volume.
     overlap = config.wall_thickness / 2.0
 
-    # Build the surface slab lying flat (along +Y, thickness in Z),
-    # then shift it back by *overlap* so the near edge sits inside the
-    # wall before rotation.
     slab = (
         cq.Workplane("XY")
         .box(
             config.surface_width,
-            effective_length + overlap,
-            config.surface_thickness,
+            effective_length,
+            config.surface_thickness + overlap,
             centered=(True, False, False),
         )
-        .translate((0, -overlap, 0))
+        .translate((0, 0, -overlap))
     )
 
     # Rotation angle: overhang_angle is from vertical, so the rotation

--- a/tests/test_overhang_model.py
+++ b/tests/test_overhang_model.py
@@ -219,12 +219,12 @@ class TestMakeOverhangSurface:
         overlap = config.wall_thickness / 2.0
         mock_wp.box.assert_called_once_with(
             config.surface_width,
-            config.surface_length + overlap,
-            config.surface_thickness,
+            config.surface_length,
+            config.surface_thickness + overlap,
             centered=(True, False, False),
         )
         mock_wp.rotate.assert_called_once()
-        # Two translates: one to shift slab into wall, one for final position
+        # Two translates: one to shift slab down (-Z) for overlap, one for final position
         assert mock_wp.translate.call_count == 2
 
     @patch("filament_calibrator.overhang_model.cq")
@@ -246,10 +246,10 @@ class TestMakeOverhangSurface:
         assert rot_call[0][1] == (1, 0, 0)
         assert rot_call[0][2] == -60.0
 
-        # First translate shifts slab into wall, second positions at wall
+        # First translate shifts slab down (-Z) for wall overlap, second positions at wall
         assert mock_wp.translate.call_count == 2
         overlap_translate = mock_wp.translate.call_args_list[0]
-        assert overlap_translate[0][0] == (0, -config.wall_thickness / 2.0, 0)
+        assert overlap_translate[0][0] == (0, 0, -config.wall_thickness / 2.0)
 
     @patch("filament_calibrator.overhang_model.cq")
     def test_length_capped_for_steep_angles(self, mock_cq):
@@ -265,9 +265,7 @@ class TestMakeOverhangSurface:
         # angle=20: max_length = 20/cos(20°) ≈ 21.28 < 25
         _make_overhang_surface(config, 20, 0.0)
         box_call = mock_wp.box.call_args
-        overlap = config.wall_thickness / 2.0
-        slab_y = box_call[0][1]
-        effective = slab_y - overlap
+        effective = box_call[0][1]  # Y dimension is the effective length
         assert effective < config.surface_length
         # Tip should be at or above base_height
         tip_z = config.wall_height - effective * math.cos(math.radians(20))
@@ -286,8 +284,7 @@ class TestMakeOverhangSurface:
 
         _make_overhang_surface(config, 90, 0.0)
         box_call = mock_wp.box.call_args
-        overlap = config.wall_thickness / 2.0
-        assert box_call[0][1] == config.surface_length + overlap
+        assert box_call[0][1] == config.surface_length
 
     @patch("filament_calibrator.overhang_model.cq")
     def test_length_not_capped_for_shallow_angles(self, mock_cq):
@@ -303,8 +300,7 @@ class TestMakeOverhangSurface:
         # angle=70: max_length = 20/cos(70°) ≈ 58.5 > 25
         _make_overhang_surface(config, 70, 0.0)
         box_call = mock_wp.box.call_args
-        overlap = config.wall_thickness / 2.0
-        assert box_call[0][1] == config.surface_length + overlap
+        assert box_call[0][1] == config.surface_length
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Changed overhang slab overlap from -Y translate to -Z translate so that after rotation the extra material ends up inside the wall volume rather than above it
- The previous -Y shift rotated above the wall top for all overhang angles, leaving slabs touching only at an edge (boolean union failure)
- Points at -Z rotate into the wall (both -Y and -Z in world coords) for all angles 0 < angle < 90

## Test plan
- [x] All 1299 tests pass with 100% coverage
- [ ] Print overhang test and verify all surfaces are attached to the wall


🤖 Generated with [Claude Code](https://claude.com/claude-code)