### PR TITLE
Fix overhang slab length capping for -Z overlap

### DIFF
--- a/src/filament_calibrator/overhang_model.py
+++ b/src/filament_calibrator/overhang_model.py
@@ -172,17 +172,6 @@ def _make_overhang_surface(
     wall_y_front = -(td / 2.0) + config.wall_thickness
     pivot_z = config.base_height + config.wall_height
 
-    # Cap surface length so the tip doesn't descend below the base plate.
-    # After rotation, the tip Z = pivot_z - length * cos(angle).
-    # We need tip Z >= base_height, so length <= wall_height / cos(angle).
-    angle_rad = math.radians(angle_deg)
-    cos_a = math.cos(angle_rad)
-    if cos_a > 1e-9:
-        max_length = config.wall_height / cos_a
-    else:
-        max_length = config.surface_length
-    effective_length = min(config.surface_length, max_length)
-
     # Extend the slab downward (-Z) so that after rotation the extra
     # material ends up *inside* the wall volume, creating a proper
     # volumetric overlap for CadQuery's boolean union.
@@ -194,6 +183,21 @@ def _make_overhang_surface(
     # wall for all angles 0 < angle < 90.  A -Y shift, by contrast,
     # would rotate *above* the pivot and miss the wall volume.
     overlap = config.wall_thickness / 2.0
+
+    # Cap surface length so the tip doesn't descend below the base plate.
+    # The lowest world-Z point is at local (0, length, -overlap).  After
+    # rotation the Z contribution is:
+    #   z_tip = pivot_z - length·cos(angle) - overlap·sin(angle)
+    # We need z_tip >= base_height, i.e.
+    #   length <= (wall_height - overlap·sin(angle)) / cos(angle).
+    angle_rad = math.radians(angle_deg)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+    if cos_a > 1e-9:
+        max_length = (config.wall_height - overlap * sin_a) / cos_a
+    else:
+        max_length = config.surface_length
+    effective_length = min(config.surface_length, max_length)
 
     slab = (
         cq.Workplane("XY")

--- a/tests/test_overhang_model.py
+++ b/tests/test_overhang_model.py
@@ -262,13 +262,16 @@ class TestMakeOverhangSurface:
         mock_wp.rotate.return_value = mock_wp
         mock_wp.translate.return_value = mock_wp
 
-        # angle=20: max_length = 20/cos(20°) ≈ 21.28 < 25
+        # angle=20: max_length = (20 - 2.5*sin(20°))/cos(20°) ≈ 20.37 < 25
         _make_overhang_surface(config, 20, 0.0)
         box_call = mock_wp.box.call_args
         effective = box_call[0][1]  # Y dimension is the effective length
+        overlap = config.wall_thickness / 2.0
         assert effective < config.surface_length
-        # Tip should be at or above base_height
-        tip_z = config.wall_height - effective * math.cos(math.radians(20))
+        # Lowest point includes overlap contribution: z = wh - len*cos - overlap*sin
+        angle_rad = math.radians(20)
+        tip_z = (config.wall_height - effective * math.cos(angle_rad)
+                 - overlap * math.sin(angle_rad))
         assert tip_z >= -0.01  # allow tiny float tolerance
 
     @patch("filament_calibrator.overhang_model.cq")


### PR DESCRIPTION
## Summary
- The length cap formula didn't account for the -Z overlap extension contributing `overlap·sin(angle)` downward after rotation
- Updated formula: `max_length = (wall_height - overlap·sin(angle)) / cos(angle)`
- Follows PR #71 which changed the overlap direction from -Y to -Z

## Test plan
- [x] All 1299 tests pass with 100% coverage
- [ ] Print overhang test and verify no slabs descend below the base


🤖 Generated with [Claude Code](https://claude.com/claude-code)