### PR TITLE
Fix documentation inaccuracies from full audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,10 @@ src/filament_calibrator/
                     #   _apply_config, _resolve_output_dir)
   config.py         # TOML config file loading
   model.py          # CadQuery parametric temperature tower model
+  _cq_compat.py    # CadQuery/casadi import compatibility helpers for
+                    #   PyInstaller bundles (stub_casadi, ensure_cq)
   slicer.py         # PrusaSlicer CLI wrapper (slice_tower, slice_flow_specimen,
-                    #   slice_pa_specimen, slice_em_specimen,
+                    #   slice_pa_specimen, slice_pa_pattern, slice_em_specimen,
                     #   slice_retraction_specimen, slice_shrinkage_specimen,
                     #   slice_bridge_specimen, slice_overhang_specimen,
                     #   slice_tolerance_specimen, slice_cooling_specimen)
@@ -79,7 +81,7 @@ src/filament_calibrator/
   pa_pattern.py     # CadQuery parametric chevron pattern model for PA calibration
   pa_insert.py      # G-code pressure advance command insertion
   ini_writer.py     # Merge calibration results into PrusaSlicer .ini configs.
-                    #   CalibrationResults dataclass: temperature,
+                    #   CalibrationResults dataclass: printer, temperature,
                     #   max_volumetric_speed, pa_value, extrusion_multiplier,
                     #   retraction_length, retraction_speed, xy_shrinkage,
                     #   z_shrinkage.
@@ -116,7 +118,7 @@ src/filament_calibrator/
 ### Key Dependencies
 
 - **cadquery** (>= 2.4): Parametric CAD model generation (OCCT kernel)
-- **gcode-lib** (>= 1.1.0): G-code parsing, PrusaSlicer integration,
+- **gcode-lib** (>= 1.1.6): G-code parsing, PrusaSlicer integration,
   PrusaLink API, filament presets, printer G-code templates, thumbnail
   injection, INI parsing/writing helpers, flow/PA helpers. Published on PyPI.
 - **vtk** (>= 9.0): Off-screen STL rendering for bgcode thumbnail
@@ -346,13 +348,14 @@ Entry points:
   WINDOW_INTERVAL, LABEL_DEPTH, LABEL_FONT_SIZE).
 - **Change bridge test geometry**: Edit constants in `bridge_model.py`
   (DEFAULT_SPANS, PILLAR_WIDTH, PILLAR_DEPTH, PILLAR_HEIGHT,
-  BRIDGE_THICKNESS, BASE_HEIGHT).
+  BRIDGE_THICKNESS, BASE_HEIGHT, BASE_MARGIN).
 - **Change overhang test geometry**: Edit constants in `overhang_model.py`
   (DEFAULT_ANGLES, WALL_HEIGHT, WALL_THICKNESS, SURFACE_LENGTH,
-  SURFACE_WIDTH, SURFACE_THICKNESS).
+  SURFACE_WIDTH, SURFACE_THICKNESS, SURFACE_SPACING, BASE_HEIGHT,
+  BASE_MARGIN).
 - **Change tolerance test geometry**: Edit constants in `tolerance_model.py`
-  (DEFAULT_DIAMETERS, PLATE_THICKNESS, PEG_HEIGHT, COLUMN_SPACING,
-  ROW_SPACING).
+  (DEFAULT_DIAMETERS, PLATE_THICKNESS, PEG_HEIGHT, PEG_BASE_HEIGHT,
+  COLUMN_SPACING, ROW_SPACING, PLATE_MARGIN, BASE_HEIGHT).
 - **Change cooling tower geometry**: Edit constants in `cooling_model.py`
   (TOWER_DIAMETER, BASE_LENGTH, BASE_WIDTH, BASE_HEIGHT, LEVEL_HEIGHT).
 - **Change slicer defaults**: Edit `DEFAULT_SLICER_ARGS` (temp tower),

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
-"""Automated filament temperature tower calibration for Prusa 3D printers."""
+"""CLI tool suite for 3D printer filament calibration (Prusa printers)."""
 from __future__ import annotations
 
 __version__ = "0.2.17"

--- a/src/filament_calibrator/cli.py
+++ b/src/filament_calibrator/cli.py
@@ -165,6 +165,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Path to a TOML config file. "
             "Default lookup: ./filament-calibrator.toml, "
+            "then ~/filament-calibrator.toml, "
             "then ~/.config/filament-calibrator/config.toml."
         ),
     )

--- a/src/filament_calibrator/pa_insert.py
+++ b/src/filament_calibrator/pa_insert.py
@@ -6,7 +6,7 @@ Provides two insertion strategies:
   Z-level boundaries and inserts PA commands at each height transition.
 * **X-based** (pattern method): walks G-code line by line using
   ``gcode_lib.ModalState`` to track X position and inserts PA commands when
-  the toolpath moves to a different diamond region.
+  the toolpath moves to a different chevron region.
 """
 from __future__ import annotations
 
@@ -171,7 +171,7 @@ def insert_pa_commands(
 
 @dataclass
 class PAPatternRegion:
-    """One diamond pattern's X region and PA value.
+    """One chevron pattern's X region and PA value.
 
     Attributes
     ----------
@@ -188,16 +188,16 @@ def compute_pa_pattern_regions(
     pa_values: List[float],
     x_centers: List[float],
 ) -> List[PAPatternRegion]:
-    """Build X-axis regions for each diamond pattern.
+    """Build X-axis regions for each chevron pattern.
 
     Region boundaries are placed at the midpoint between adjacent
-    diamond centres.  The leftmost region extends to ``-inf`` and the
+    chevron centres.  The leftmost region extends to ``-inf`` and the
     rightmost extends to ``+inf``.
 
     Parameters
     ----------
     pa_values: PA value for each pattern (left to right).
-    x_centers: X coordinate of each diamond's centre (left to right).
+    x_centers: X coordinate of each chevron's centre (left to right).
 
     Returns
     -------
@@ -254,7 +254,7 @@ def insert_pa_pattern_commands(
 
     Walks G-code line by line using :class:`gcode_lib.ModalState` to
     track the current X coordinate.  When an extrusion move enters a
-    different diamond's X region, a PA command is inserted before it.
+    different chevron's X region, a PA command is inserted before it.
 
     Returns a new list of :class:`gcode_lib.GCodeLine`.
 

--- a/src/filament_calibrator/slicer.py
+++ b/src/filament_calibrator/slicer.py
@@ -1,8 +1,9 @@
 """PrusaSlicer orchestration for calibration model slicing.
 
 Wraps gcode-lib's PrusaSlicer CLI helpers with sensible defaults for
-temperature tower prints, volumetric flow specimens, and pressure advance
-calibration towers.
+all eleven calibration tools: temperature tower, extrusion multiplier,
+volumetric flow, pressure advance (tower + chevron pattern), retraction
+(distance + speed), shrinkage, bridging, overhang, tolerance, and cooling.
 """
 from __future__ import annotations
 
@@ -23,6 +24,12 @@ DEFAULT_SLICER_ARGS: Dict[str, str] = {
     "fill-density": "15%",
     "skirts": "1",
 }
+"""Slicer defaults applied when no ``--config-ini`` is supplied.
+
+These produce a reasonable temp tower slice with 0.2mm layers, 2 perimeters,
+and 15% infill — enough structure to evaluate temperature quality without
+wasting filament.  Support material is disabled by PrusaSlicer's default.
+"""
 
 # Default bed centre for Prusa printers (250 × 220 mm bed).
 # Used with PrusaSlicer's --center flag to place the model on the bed.
@@ -33,12 +40,6 @@ DEFAULT_BED_CENTER: str = "125,110"
 # PrusaSlicer 2.9+ requires the format suffix (e.g. /PNG) in each size spec.
 DEFAULT_THUMBNAILS: str = "16x16/PNG,220x124/PNG"
 DEFAULT_BED_SHAPE: str = "0x0,250x0,250x220,0x220"
-"""Slicer defaults applied when no ``--config-ini`` is supplied.
-
-These produce a reasonable temp tower slice with 0.2mm layers, 2 perimeters,
-and 15% infill — enough structure to evaluate temperature quality without
-wasting filament.  Support material is disabled by PrusaSlicer's default.
-"""
 
 # Slicer settings for spiral-vase flow specimen (used when no .ini provided).
 VASE_MODE_SLICER_ARGS: Dict[str, str] = {
@@ -72,7 +73,7 @@ layers.  ``layer-height`` and ``extrusion-width`` are passed explicitly
 by :func:`slice_pa_specimen` so they are **not** included here.
 """
 
-# Slicer settings for PA diamond pattern (used when no .ini provided).
+# Slicer settings for PA chevron pattern (used when no .ini provided).
 PA_PATTERN_SLICER_ARGS: Dict[str, str] = {
     "first-layer-height": "0.2",
     "top-solid-layers": "0",
@@ -80,7 +81,7 @@ PA_PATTERN_SLICER_ARGS: Dict[str, str] = {
     "fill-density": "0%",
     "skirts": "1",
 }
-"""Slicer defaults for PA diamond pattern calibration prints.
+"""Slicer defaults for PA chevron pattern calibration prints.
 
 Same as :data:`PA_SLICER_ARGS` but ``perimeters`` is *not* included —
 it is passed explicitly by :func:`slice_pa_pattern` so the user can
@@ -478,7 +479,7 @@ def slice_pa_pattern(
     printer_model: Optional[str] = None,
     binary_gcode: bool = True,
 ) -> gl.RunResult:
-    """Slice a PA diamond pattern STL.
+    """Slice a PA chevron pattern STL.
 
     When *config_ini* is ``None``, :data:`PA_PATTERN_SLICER_ARGS` are
     applied together with the explicit *layer_height*, *extrusion_width*,


### PR DESCRIPTION
## Summary
Full audit of all documentation (CLAUDE.md, module docstrings, CLI help text) found and fixed 11 issues:

**CLAUDE.md:**
- Add missing `_cq_compat.py` to architecture file listing
- Add `slice_pa_pattern` to slicer.py function list
- Update gcode-lib version requirement (`>= 1.1.0` → `>= 1.1.6`)
- Add missing constants to bridge, overhang, tolerance model listings
- Add `printer` field to CalibrationResults listing

**Source docstrings:**
- `__init__.py`: "temperature tower calibration" → "CLI tool suite for filament calibration"
- `slicer.py`: module docstring expanded from 3 to all 11 tools
- `slicer.py`: relocate misplaced `DEFAULT_SLICER_ARGS` docstring (was attached to `DEFAULT_BED_SHAPE`)
- `slicer.py` + `pa_insert.py`: "diamond" → "chevron" terminology (consistent with `pa_pattern.py`)
- `cli.py`: add `~/filament-calibrator.toml` to `--config` help text lookup order

## Test plan
- [x] All 1299 tests pass with 100% coverage
- [x] No behavioral changes — docstring/comment/help-text only


🤖 Generated with [Claude Code](https://claude.com/claude-code)