### PR TITLE
Bump gcode-lib dependency to >= 1.1.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ src/filament_calibrator/
 ### Key Dependencies
 
 - **cadquery** (>= 2.4): Parametric CAD model generation (OCCT kernel)
-- **gcode-lib** (>= 1.1.6): G-code parsing, PrusaSlicer integration,
+- **gcode-lib** (>= 1.1.7): G-code parsing, PrusaSlicer integration,
   PrusaLink API, filament presets, printer G-code templates, thumbnail
   injection, INI parsing/writing helpers, flow/PA helpers. Published on PyPI.
 - **vtk** (>= 9.0): Off-screen STL rendering for bgcode thumbnail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 dependencies = [
     "cadquery>=2.4",
-    "gcode-lib>=1.1.6",
+    "gcode-lib>=1.1.7",
     "tomli>=2.0; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
## Summary
- Update gcode-lib minimum version from 1.1.6 to 1.1.7 in pyproject.toml and CLAUDE.md
- Links to [gcode-lib v1.1.7 release](https://github.com/hyiger/gcode-lib/releases/tag/v1.1.7)

## gcode-lib v1.1.7 changes
- Harden BGCode parsing and fix URL/path validation
- Detect hardened nozzle from Diamondback printer_settings_id

## Test plan
- [x] Dependency version updated in pyproject.toml
- [x] CLAUDE.md reference updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)