### PR TITLE
Fix PyInstaller spec and bump to 0.2.20

### DIFF
--- a/pyinstaller/filament-calibrator.spec
+++ b/pyinstaller/filament-calibrator.spec
@@ -22,6 +22,7 @@ a = Analysis(
     hiddenimports=[
         # --- filament_calibrator package ---
         "filament_calibrator",
+        "filament_calibrator._cq_compat",
         "filament_calibrator.gui",
         "filament_calibrator.cli",
         "filament_calibrator.config",
@@ -40,8 +41,19 @@ a = Analysis(
         "filament_calibrator.retraction_cli",
         "filament_calibrator.retraction_model",
         "filament_calibrator.retraction_insert",
+        "filament_calibrator.retraction_speed_cli",
+        "filament_calibrator.retraction_speed_insert",
         "filament_calibrator.shrinkage_cli",
         "filament_calibrator.shrinkage_model",
+        "filament_calibrator.bridge_cli",
+        "filament_calibrator.bridge_model",
+        "filament_calibrator.overhang_cli",
+        "filament_calibrator.overhang_model",
+        "filament_calibrator.tolerance_cli",
+        "filament_calibrator.tolerance_model",
+        "filament_calibrator.cooling_cli",
+        "filament_calibrator.cooling_model",
+        "filament_calibrator.cooling_insert",
         "filament_calibrator.ini_writer",
         # --- external ---
         "gcode_lib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.19"
+version = "0.2.20"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """CLI tool suite for 3D printer filament calibration (Prusa printers)."""
 from __future__ import annotations
 
-__version__ = "0.2.19"
+__version__ = "0.2.20"


### PR DESCRIPTION
## Summary
- Add 12 missing hidden imports to `pyinstaller/filament-calibrator.spec` for the 5 new calibration tools (retraction speed, bridging, overhang, tolerance, cooling) and the `_cq_compat` module
- Bump version to 0.2.20

Without these hidden imports, the standalone GUI binary (`FilamentCalibrator.exe`) crashes with `ModuleNotFoundError` at runtime.

## Test plan
- [x] All 1290 tests pass
- [ ] Create release to trigger CI build workflow
- [ ] Verify standalone binary builds successfully on all 4 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)