### PR TITLE
Bump gcode-lib to >= 1.1.8, version to 0.2.22

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ src/filament_calibrator/
 ### Key Dependencies
 
 - **cadquery** (>= 2.4): Parametric CAD model generation (OCCT kernel)
-- **gcode-lib** (>= 1.1.7): G-code parsing, PrusaSlicer integration,
+- **gcode-lib** (>= 1.1.8): G-code parsing, PrusaSlicer integration,
   PrusaLink API, filament presets, printer G-code templates, thumbnail
   injection, INI parsing/writing helpers, flow/PA helpers. Published on PyPI.
 - **vtk** (>= 9.0): Off-screen STL rendering for bgcode thumbnail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "filament-calibrator"
-version = "0.2.21"
+version = "0.2.22"
 description = "CLI tool suite for 3D printer filament calibration — temperature tower, extrusion multiplier, volumetric flow, pressure advance, retraction, and shrinkage tests"
 readme = "README.md"
 license = "GPL-3.0-only"
@@ -32,7 +32,7 @@ classifiers = [
 
 dependencies = [
     "cadquery>=2.4",
-    "gcode-lib>=1.1.7",
+    "gcode-lib>=1.1.8",
     "tomli>=2.0; python_version < '3.11'",
 ]
 

--- a/src/filament_calibrator/__init__.py
+++ b/src/filament_calibrator/__init__.py
@@ -1,4 +1,4 @@
 """CLI tool suite for 3D printer filament calibration (Prusa printers)."""
 from __future__ import annotations
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"


### PR DESCRIPTION
## Summary
- Bump gcode-lib dependency to >= 1.1.8 which resolves macOS `.app` bundle paths in `find_prusaslicer_executable()`
- Bump version to 0.2.22

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)